### PR TITLE
[12] [Soroban] Add support for multiple royalty recipients

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -69,7 +69,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype,
-    symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String,
+    symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Vec,
 };
 
 /// Custom errors for the NFT contract
@@ -94,6 +94,8 @@ pub enum Error {
     InvalidSignature = 8,
     /// No backend signer public key has been registered yet
     SignerNotSet = 9,
+    /// Royalty split is invalid
+    InvalidRoyaltySplit = 10,
 }
 
 /// Token ID type
@@ -116,10 +118,17 @@ pub struct TokenData {
 /// for any SEP-0041 custom Stellar asset.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Royalty {
+pub struct RoyaltyRecipient {
     pub recipient: Address,
-    /// Royalty in basis points (0-10000, where 10000 = 100%)
     pub basis_points: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Royalty {
+    /// Multi-recipient split. Platform recipient is automatically added with 1%
+    /// if not present.
+    pub recipients: Vec<RoyaltyRecipient>,
     /// Optional SEP-0041 asset contract address.
     /// `None` → royalties expected in XLM (native).
     pub asset_address: Option<Address>,
@@ -161,6 +170,8 @@ pub enum DataKey {
     ClipIdMinted(u32),
     /// Ed25519 public key of the trusted backend signer (instance storage)
     Signer,
+    /// Platform recipient used for default 1% royalty cut
+    PlatformRecipient,
 }
 
 /// Event emitted when a new NFT is minted
@@ -194,6 +205,7 @@ impl ClipsNftContract {
         // NextTokenId starts at 1; total_supply = NextTokenId - 1
         env.storage().instance().set(&DataKey::NextTokenId, &1u32);
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().set(&DataKey::PlatformRecipient, &admin);
         // Signer is not set at init — call set_signer before minting.
     }
 
@@ -296,9 +308,7 @@ impl ClipsNftContract {
             return Err(Error::TokenAlreadyMinted);
         }
 
-        if royalty.basis_points > 10000 {
-            return Err(Error::RoyaltyTooHigh);
-        }
+        let royalty = Self::normalize_royalty(&env, royalty)?;
 
         // One instance read
         let token_id: TokenId = env
@@ -445,13 +455,17 @@ impl ClipsNftContract {
             .get(&DataKey::Royalty(token_id))
             .ok_or(Error::InvalidTokenId)?;
 
-        let royalty_amount = sale_price
-            .saturating_mul(royalty.basis_points as i128)
-            / 10_000;
+        let mut total_royalty_amount: i128 = 0;
+        for idx in 0..royalty.recipients.len() {
+            let split = royalty.recipients.get(idx).ok_or(Error::InvalidRoyaltySplit)?;
+            total_royalty_amount = total_royalty_amount
+                .saturating_add(sale_price.saturating_mul(split.basis_points as i128) / 10_000);
+        }
+        let first = royalty.recipients.get(0).ok_or(Error::InvalidRoyaltySplit)?;
 
         Ok(RoyaltyInfo {
-            receiver: royalty.recipient,
-            royalty_amount,
+            receiver: first.recipient,
+            royalty_amount: total_royalty_amount,
             asset_address: royalty.asset_address,
         })
     }
@@ -468,21 +482,28 @@ impl ClipsNftContract {
     ) -> Result<(), Error> {
         payer.require_auth();
 
-        let info = Self::royalty_info(env.clone(), token_id, sale_price)?;
-
-        if info.royalty_amount == 0 {
-            return Ok(());
+        if sale_price <= 0 {
+            return Err(Error::InvalidSalePrice);
         }
-
-        let asset_address = info.asset_address.ok_or(Error::InvalidRecipient)?;
-
+        let royalty: Royalty = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Royalty(token_id))
+            .ok_or(Error::InvalidTokenId)?;
+        let asset_address = royalty.asset_address.clone().ok_or(Error::InvalidRecipient)?;
         let token_client = soroban_sdk::token::TokenClient::new(&env, &asset_address);
-        token_client.transfer(&payer, &info.receiver, &info.royalty_amount);
-
-        env.events().publish(
-            (symbol_short!("royalty"),),
-            (token_id, info.receiver, info.royalty_amount, asset_address),
-        );
+        for idx in 0..royalty.recipients.len() {
+            let split = royalty.recipients.get(idx).ok_or(Error::InvalidRoyaltySplit)?;
+            let amount = sale_price.saturating_mul(split.basis_points as i128) / 10_000;
+            if amount == 0 {
+                continue;
+            }
+            token_client.transfer(&payer, &split.recipient, &amount);
+            env.events().publish(
+                (symbol_short!("royalty"),),
+                (token_id, split.recipient, amount, asset_address.clone()),
+            );
+        }
 
         Ok(())
     }
@@ -501,9 +522,7 @@ impl ClipsNftContract {
             return Err(Error::InvalidTokenId);
         }
 
-        if new_royalty.basis_points > 10000 {
-            return Err(Error::RoyaltyTooHigh);
-        }
+        let new_royalty = Self::normalize_royalty(&env, new_royalty)?;
 
         env.storage()
             .persistent()
@@ -624,6 +643,41 @@ impl ClipsNftContract {
         }
         Ok(())
     }
+
+    fn normalize_royalty(env: &Env, royalty: Royalty) -> Result<Royalty, Error> {
+        if royalty.recipients.is_empty() {
+            return Err(Error::InvalidRoyaltySplit);
+        }
+        let platform: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PlatformRecipient)
+            .ok_or(Error::InvalidRecipient)?;
+        let mut recipients = royalty.recipients;
+        let mut has_platform = false;
+        let mut total_bps: u32 = 0;
+        for idx in 0..recipients.len() {
+            let split = recipients.get(idx).ok_or(Error::InvalidRoyaltySplit)?;
+            if split.recipient == platform {
+                has_platform = true;
+            }
+            total_bps = total_bps.saturating_add(split.basis_points);
+        }
+        if !has_platform {
+            recipients.push_back(RoyaltyRecipient {
+                recipient: platform,
+                basis_points: 100, // fixed default 1%
+            });
+            total_bps = total_bps.saturating_add(100);
+        }
+        if total_bps > 10_000 {
+            return Err(Error::RoyaltyTooHigh);
+        }
+        Ok(Royalty {
+            recipients,
+            asset_address: royalty.asset_address,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -643,8 +697,16 @@ mod tests {
         (env, admin, user1, user2)
     }
 
-    fn default_royalty(recipient: Address) -> Royalty {
-        Royalty { recipient, basis_points: 500, asset_address: None }
+    fn default_royalty(env: &Env, recipient: Address) -> Royalty {
+        let mut recipients = Vec::new(env);
+        recipients.push_back(RoyaltyRecipient {
+            recipient,
+            basis_points: 500,
+        });
+        Royalty {
+            recipients,
+            asset_address: None,
+        }
     }
 
     /// Build the canonical mint payload and sign it with `signer_secret`.
@@ -698,7 +760,7 @@ mod tests {
             to,
             &clip_id,
             &uri,
-            &default_royalty(to.clone()),
+            &default_royalty(env, to.clone()),
             &sig,
         )
     }
@@ -779,7 +841,7 @@ mod tests {
         let uri = String::from_str(&env, "ipfs://QmExample");
         let sig = sign_mint(&env, &kp, &user1, 1, &uri);
 
-        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(user1.clone()), &sig);
+        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig);
         assert_eq!(result, Err(Ok(Error::SignerNotSet)));
     }
 
@@ -799,7 +861,7 @@ mod tests {
         let bad_sig = sign_mint(&env, &wrong_kp, &user1, 1, &uri);
 
         // ed25519_verify traps on bad sig, which surfaces as a panic in tests
-        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(user1.clone()), &bad_sig);
+        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &bad_sig);
     }
 
     #[test]
@@ -815,7 +877,7 @@ mod tests {
         // Signature is over user2 but we pass user1 as `to`
         let sig_for_user2 = sign_mint(&env, &kp, &user2, 1, &uri);
 
-        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(user1.clone()), &sig_for_user2);
+        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig_for_user2);
     }
 
     #[test]
@@ -831,7 +893,7 @@ mod tests {
         // Signature is over clip_id=99 but we pass clip_id=1
         let sig_for_99 = sign_mint(&env, &kp, &user1, 99, &uri);
 
-        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(user1.clone()), &sig_for_99);
+        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig_for_99);
     }
 
     #[test]
@@ -855,7 +917,7 @@ mod tests {
         // Old signer's signature should now fail
         let uri = String::from_str(&env, "ipfs://QmExample");
         let old_sig = sign_mint(&env, &kp1, &user1, 1, &uri);
-        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(user1.clone()), &old_sig);
+        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &old_sig);
         assert!(result.is_err());
     }
 
@@ -903,8 +965,7 @@ mod tests {
         let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
 
         let info = client.royalty_info(&token_id, &1_000_000i128);
-        assert_eq!(info.receiver, user1);
-        assert_eq!(info.royalty_amount, 50_000i128);
+        assert_eq!(info.royalty_amount, 60_000i128);
         assert_eq!(info.asset_address, None);
     }
 
@@ -917,9 +978,13 @@ mod tests {
         let kp = register_signer(&env, &client, &admin);
 
         let asset_addr = Address::generate(&env);
-        let royalty = Royalty {
+        let mut recipients = Vec::new(&env);
+        recipients.push_back(RoyaltyRecipient {
             recipient: user1.clone(),
             basis_points: 1000,
+        });
+        let royalty = Royalty {
+            recipients,
             asset_address: Some(asset_addr.clone()),
         };
         let uri = String::from_str(&env, "ipfs://QmCustom");
@@ -927,7 +992,7 @@ mod tests {
         let token_id = client.mint(&admin, &user1, &2u32, &uri, &royalty, &sig);
 
         let info = client.royalty_info(&token_id, &500i128);
-        assert_eq!(info.royalty_amount, 50i128);
+        assert_eq!(info.royalty_amount, 55i128);
         assert_eq!(info.asset_address, Some(asset_addr));
     }
 
@@ -942,16 +1007,21 @@ mod tests {
         let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
 
         let asset_addr = Address::generate(&env);
-        let new_royalty = Royalty {
+        let mut recipients = Vec::new(&env);
+        recipients.push_back(RoyaltyRecipient {
             recipient: user2.clone(),
             basis_points: 1000,
+        });
+        let new_royalty = Royalty {
+            recipients,
             asset_address: Some(asset_addr.clone()),
         };
         client.set_royalty(&admin, &token_id, &new_royalty);
 
         let stored = client.get_royalty(&token_id);
-        assert_eq!(stored.recipient, user2);
-        assert_eq!(stored.basis_points, 1000);
+        assert_eq!(stored.recipients.get(0).unwrap().recipient, user2);
+        assert_eq!(stored.recipients.get(0).unwrap().basis_points, 1000);
+        assert_eq!(stored.recipients.len(), 2);
         assert_eq!(stored.asset_address, Some(asset_addr));
     }
 
@@ -1001,7 +1071,7 @@ mod tests {
 
         let uri = String::from_str(&env, "ipfs://QmPaused");
         let sig = sign_mint(&env, &kp, &user1, 1, &uri);
-        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(user1.clone()), &sig);
+        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
     }
 

--- a/clips_nft/test_snapshots/tests/test_burn.1.json
+++ b/clips_nft/test_snapshots/tests/test_burn.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "43b4d16a7433e18ef2b0d3732025ddc8da7127af82d602b95e00803061082eae"
+                  "bytes": "d68cc9aa01caee7ed7ddecbd0aeb3ebc7eb00b01f2458295e90f29d7792705ca"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "6715adf360b198b565e74691b6ec798a936597032c46b6e13fcd7391e948067544eb7333ea148928db14ee8ef5f056b4cb501bd26f4644378e257f683456f003"
+                  "bytes": "08ea3c8f7e9dba476c0dc476871e2e102b528bdcccfc196df36e61284132f88a3d9664286952372c0cd1db4605686c185fceadbc68c2fe60fe6391938441e607"
                 }
               ]
             }
@@ -140,24 +153,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "6715adf360b198b565e74691b6ec798a936597032c46b6e13fcd7391e948067544eb7333ea148928db14ee8ef5f056b4cb501bd26f4644378e257f683456f003"
+                  "bytes": "08ea3c8f7e9dba476c0dc476871e2e102b528bdcccfc196df36e61284132f88a3d9664286952372c0cd1db4605686c185fceadbc68c2fe60fe6391938441e607"
                 }
               ]
             }
@@ -340,18 +366,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -461,12 +520,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "43b4d16a7433e18ef2b0d3732025ddc8da7127af82d602b95e00803061082eae"
+                        "bytes": "d68cc9aa01caee7ed7ddecbd0aeb3ebc7eb00b01f2458295e90f29d7792705ca"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_burn_emits_event.1.json
+++ b/clips_nft/test_snapshots/tests/test_burn_emits_event.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "5699194a4d644366e21cd35c4ddb5a0efa80f472e864a8d3fa1f1763957de3dd"
+                  "bytes": "30f419a98cf457969649fcde5c556ebe35d2740f3bcb380a764f54b51f11477e"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "fb3011799b87ffdf78a322c4f2f661c886f25710b66b51ffb810b114ec94c95742a417b2fc5466ffc4579a547249590e6e7d4dc8966db5786c1dae94481e600e"
+                  "bytes": "46c50d847d669f1603344d080b55caff12585a042da2d030cbdca6528ece2652bc2943bf9238ac4c5f01ead70946fdeb18876ad3dd8339310a6fd207e0ac1904"
                 }
               ]
             }
@@ -234,12 +247,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "5699194a4d644366e21cd35c4ddb5a0efa80f472e864a8d3fa1f1763957de3dd"
+                        "bytes": "30f419a98cf457969649fcde5c556ebe35d2740f3bcb380a764f54b51f11477e"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_clip_token_id_lookup.1.json
+++ b/clips_nft/test_snapshots/tests/test_clip_token_id_lookup.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "1b68ec5ded2408345c72a4fe92cb0d6b9288ee8257b8add1e3679e6f56664d0c"
+                  "bytes": "fdadb14e47b7849970ea9ebd273d3c93032bf924e282af9d9ddc7ad024c860d5"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "768a84085333365a2953ff4a418fa7b04ba546fd84a2f7159306e8074f978ed6f4035f0ea1e2d39d1cd892cf8a2fdf3c22c0fdf542d98d8cc6c56e3bf3a0d80f"
+                  "bytes": "0695f7d97f501e7d8b73ec5bcaf20acba375b4f5dbfe718bee49438d1ad0f236c45501283f059af9d66a3a7535ff436bf61aff6d2f5c1548c552dfa49ae0cc09"
                 }
               ]
             }
@@ -220,18 +233,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -341,12 +387,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "1b68ec5ded2408345c72a4fe92cb0d6b9288ee8257b8add1e3679e6f56664d0c"
+                        "bytes": "fdadb14e47b7849970ea9ebd273d3c93032bf924e282af9d9ddc7ad024c860d5"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_double_mint_same_clip_id_panics.1.json
+++ b/clips_nft/test_snapshots/tests/test_double_mint_same_clip_id_panics.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "328d356a844e794bfc87537cab4f3a5dfeee7499028d84682b6bb9d1a8603fc9"
+                  "bytes": "9bfc5ac4be487d076e49b3fee1ba5987d4b471a958aaa43a454146ea09380c85"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "2d29c9e0345326c75d88ee509bfa760b2e8b185c5347158c6083ed5361993c0f85c0fd61de7ed2af9fbf3e03e3ad17483f51a36cc212ab799be7c7f0afdcff0e"
+                  "bytes": "bc82bea03787576845ce46cdb499aee756da92011b7ecc5f636b0b32aed86eb6e842383e837d282c8393d0147f980333adab80cbf7943b331b93091f1660240e"
                 }
               ]
             }
@@ -220,18 +233,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -341,12 +387,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "328d356a844e794bfc87537cab4f3a5dfeee7499028d84682b6bb9d1a8603fc9"
+                        "bytes": "9bfc5ac4be487d076e49b3fee1ba5987d4b471a958aaa43a454146ea09380c85"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_emits_event.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_emits_event.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "18c94cbff857b88a2ee6d0035e787ef73f72015875cb78cf4c04033e94878c73"
+                  "bytes": "83a27ecd2b6b471a655e00415114e367625bf23364ddd44c53b1037b59df9c24"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "3e078e58b5966b793321ceca5f1c8f1bd2a718fefeb146712aeb5701a623a9aaf1fda94b34869c3331d14b9f2ad5afcfca19705ff4f4d14a392b319350334c04"
+                  "bytes": "9bc3acaf5aa0f39e6172b89fa3707317cd33ce38522d5499b239f1c635a8813d6a7e62a0ca142455439335fa1e7094e1b14f5a37afe58335fa59fdcd2500240f"
                 }
               ]
             }
@@ -219,18 +232,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -340,12 +386,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "18c94cbff857b88a2ee6d0035e787ef73f72015875cb78cf4c04033e94878c73"
+                        "bytes": "83a27ecd2b6b471a655e00415114e367625bf23364ddd44c53b1037b59df9c24"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_clip_id_in_payload.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_clip_id_in_payload.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "6864cb510e8d82dfb6c8c7248e5a17d4d5a4b930ee7b98ba4b63732d41d3a6b1"
+                  "bytes": "287506615de6f1359d85f78d0ac89a83d9b4537ab3c9015c78432be07b611eae"
                 }
               ]
             }
@@ -116,12 +116,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "6864cb510e8d82dfb6c8c7248e5a17d4d5a4b930ee7b98ba4b63732d41d3a6b1"
+                        "bytes": "287506615de6f1359d85f78d0ac89a83d9b4537ab3c9015c78432be07b611eae"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_owner_in_payload.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_owner_in_payload.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "801dbe1db7f04105534d0f96f1019ad08985335d9f9af47bebebd223d3632f3a"
+                  "bytes": "4eee95ea7d70f2693c80e057bd8be4102f502cd36c08e8b004939bdf912d67aa"
                 }
               ]
             }
@@ -116,12 +116,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "801dbe1db7f04105534d0f96f1019ad08985335d9f9af47bebebd223d3632f3a"
+                        "bytes": "4eee95ea7d70f2693c80e057bd8be4102f502cd36c08e8b004939bdf912d67aa"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_signature.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_signature.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "e056b85029bf08945b7c9234bd3f82ce9dff512c31798b935e79c7c34c85848a"
+                  "bytes": "33747c6733eea25d728dfaea2cb2832ef694d75eb321ab4076cdd1d48ddca957"
                 }
               ]
             }
@@ -116,12 +116,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "e056b85029bf08945b7c9234bd3f82ce9dff512c31798b935e79c7c34c85848a"
+                        "bytes": "33747c6733eea25d728dfaea2cb2832ef694d75eb321ab4076cdd1d48ddca957"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_without_signer_set.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_without_signer_set.1.json
@@ -69,6 +69,18 @@
                       "val": {
                         "bool": false
                       }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
                     }
                   ]
                 }

--- a/clips_nft/test_snapshots/tests/test_mint_stores_owner_and_uri.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_stores_owner_and_uri.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "c0433d6c2421850f49a6467e00723bf57d208dc91dd3fada4369d2ce5fdf029b"
+                  "bytes": "91a7317be0a1be4011cb5d77b1e6f9af1638d94fc136d7206b1246db926d02c3"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "0806818891fd414f087b31cda1d10a3411d1289dcb9e0e256a6d614f0416d833e299c29e39d580aaf95d8cdadd386e7fbedf3a6c7a5d896e33d1a4f422b0550f"
+                  "bytes": "2965d16b11fc2682abe6ec9d4c26cafd8be174ca88437f152b6c28e26dc346144e6e5c3a60ea91fac96ec3935a105ee3b911110a8435a38ed38de161bc0db700"
                 }
               ]
             }
@@ -222,18 +235,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -343,12 +389,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "c0433d6c2421850f49a6467e00723bf57d208dc91dd3fada4369d2ce5fdf029b"
+                        "bytes": "91a7317be0a1be4011cb5d77b1e6f9af1638d94fc136d7206b1246db926d02c3"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_non_admin_cannot_pause.1.json
+++ b/clips_nft/test_snapshots/tests/test_non_admin_cannot_pause.1.json
@@ -69,6 +69,18 @@
                       "val": {
                         "bool": false
                       }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
                     }
                   ]
                 }

--- a/clips_nft/test_snapshots/tests/test_pause_blocks_mint.1.json
+++ b/clips_nft/test_snapshots/tests/test_pause_blocks_mint.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "9f09776024043a50266c209b4c1eee4add6b6b5db5400eb6c4b00bd34a840b9c"
+                  "bytes": "65c3a148fcf510773f9e458ea0724ae6e4316213fc8810cba61a23296567ce15"
                 }
               ]
             }
@@ -157,12 +157,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "9f09776024043a50266c209b4c1eee4add6b6b5db5400eb6c4b00bd34a840b9c"
+                        "bytes": "65c3a148fcf510773f9e458ea0724ae6e4316213fc8810cba61a23296567ce15"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_pause_blocks_transfer.1.json
+++ b/clips_nft/test_snapshots/tests/test_pause_blocks_transfer.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "79fafdc5a5d44016b276da91d6f586110dd4e9938c7b6d7c9f2699a31a3cfca4"
+                  "bytes": "14396847b9662bbf445636a470ed03d3d5204ebd3ec068cd18330a4d7bfd8452"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "7cfcd0dff33bd9f1db2a8850e3c4f8ca8d4163248b0a25485fb952b6b3ff0c532bf9ba1ea2ba866eec60a98362400ff7abc34ae4aa369707d06660256d7efb02"
+                  "bytes": "eb3d8e75b8629b2af90ba395e3a27e4f1a0a40f6292f001256997d1e2de45cb1c5d414439866cee81cc71a322206ccacdc2db0127ec1bdccf1c3443966fdff0b"
                 }
               ]
             }
@@ -259,18 +272,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -380,12 +426,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "79fafdc5a5d44016b276da91d6f586110dd4e9938c7b6d7c9f2699a31a3cfca4"
+                        "bytes": "14396847b9662bbf445636a470ed03d3d5204ebd3ec068cd18330a4d7bfd8452"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_royalty_info_custom_asset.1.json
+++ b/clips_nft/test_snapshots/tests/test_royalty_info_custom_asset.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "8367f73a2b8bd0438560e3037e0b9cf134f5249541c8d51c1e50d1d4efb14c70"
+                  "bytes": "ab1cd75c7dd2ee5b25e2fe5693a0883ea4e994cf56fee8235ac15374dfc0352a"
                 }
               ]
             }
@@ -62,24 +62,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 1000
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 1000
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "d3a493ca5a54c51d923b0d4481cc9d0a3ed85808b320a866ed97fb5bf848b66e60e9e23deeb1bbe4bf3488ca36db327df8b2c1bb7b981a105e905a8edc421009"
+                  "bytes": "37cd14eae130fb98e2067735a32f8ab23b7a4b9755449bac709e288f4897d1fc7616586542c5206f40c9349fe93510b465aafbaa14f119b82421e7c4c5ccf408"
                 }
               ]
             }
@@ -224,18 +237,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 1000
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 1000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -345,12 +391,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "8367f73a2b8bd0438560e3037e0b9cf134f5249541c8d51c1e50d1d4efb14c70"
+                        "bytes": "ab1cd75c7dd2ee5b25e2fe5693a0883ea4e994cf56fee8235ac15374dfc0352a"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_royalty_info_xlm.1.json
+++ b/clips_nft/test_snapshots/tests/test_royalty_info_xlm.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "99e35d5c31d1bdc507c2fa8261daaad43b6a718e5429ce19cf91e850cad87eb8"
+                  "bytes": "208ae447691fcf3e4a2d8d1951afe86a515f2118d55d0301407adcfa91f8e6b8"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "e12711daccb2099417640190662ce8cf8b0379a27a560b955fa3aa85792845df9e7d0a457fe6a2a4baf178bd8c525a56a01be896c7c8b1ccece1aece6ea51b0d"
+                  "bytes": "17f230fc88bdfe148fafa31ef09f240b6ed0f39dee2b352d00d408d4985f6cb664b76fc8156716b03927a60b1174b5ca04b5f73b1679de8f4c567bb33795b308"
                 }
               ]
             }
@@ -220,18 +233,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -341,12 +387,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "99e35d5c31d1bdc507c2fa8261daaad43b6a718e5429ce19cf91e850cad87eb8"
+                        "bytes": "208ae447691fcf3e4a2d8d1951afe86a515f2118d55d0301407adcfa91f8e6b8"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_set_royalty_with_custom_asset.1.json
+++ b/clips_nft/test_snapshots/tests/test_set_royalty_with_custom_asset.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "19fdc4de0b29aa56b7c26eaf346197f931a1c9fb789f1b448d4d42a83a8e09e8"
+                  "bytes": "5f8d7c84f95a363280d3183fbba68fdbcbe9eca5575d53188342cf108f574925"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "146f70ea4d0fd5f75ff17a4f1263a62f7fc4d614cb4a698019df0ca6048cc6d46069b531e64007f7dbad1c940bd12d375a1e746565d7de51013a0b168a59930f"
+                  "bytes": "f8c0d1688cadceed6198263cf30e6f3ab6eb6910d2089bce36d8cd3c9cae5ec04362632ac113ef5b71638fd1f7b617e4f29058b82d7b39ab54dbd6a7e067b300"
                 }
               ]
             }
@@ -113,18 +126,31 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 1000
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 1000
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -292,18 +318,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 1000
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 1000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -413,12 +472,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "19fdc4de0b29aa56b7c26eaf346197f931a1c9fb789f1b448d4d42a83a8e09e8"
+                        "bytes": "5f8d7c84f95a363280d3183fbba68fdbcbe9eca5575d53188342cf108f574925"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_set_signer_and_rotate.1.json
+++ b/clips_nft/test_snapshots/tests/test_set_signer_and_rotate.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "966909b56573c44f0c9010417cb58588137ab4ba17eaed983fbd59afe61a4970"
+                  "bytes": "1130b895272cd9dfdcc15006b5ff98eb0c0bf200a4ea6b05b47deaf5194d3c16"
                 }
               ]
             }
@@ -43,7 +43,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "70c14fdf704f4ff267ce938e7674579420bb2f0aad5b4caa8937a5f638ae95bf"
+                  "bytes": "de0a9a0b3f7d4017416578426ddcdad2a6570a9aa81c4b1afe45cb8844fe6952"
                 }
               ]
             }
@@ -160,12 +160,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "70c14fdf704f4ff267ce938e7674579420bb2f0aad5b4caa8937a5f638ae95bf"
+                        "bytes": "de0a9a0b3f7d4017416578426ddcdad2a6570a9aa81c4b1afe45cb8844fe6952"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_total_supply_derived_from_next_token_id.1.json
+++ b/clips_nft/test_snapshots/tests/test_total_supply_derived_from_next_token_id.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "52827f17c6f8c95b7748059d3e6a827c53f1c46631a0a7e9e6f7ac836ed9f669"
+                  "bytes": "72daf44779d92205fc2c541d85bade35c9b2477d209e1a556a484466ff849856"
                 }
               ]
             }
@@ -61,24 +61,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "a9c8ecf72696cf819b0df9b7b6cb7076beb40ef7c6955ab16673adb19d8fe86b1bd522906a3a27d1ccd2771c741651809461c9bb422e088254a52b092675a70d"
+                  "bytes": "c356c1286b058a95dd684c2a682c921a23c872d32ee0d347602d697bda4b622374ec4560c0ebb5eb13eb2d0bf9635eab0399617d1bf952de585d5a6ed3e9c708"
                 }
               ]
             }
@@ -119,24 +132,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "e5dafd7bfb84e3ee6a2747e9b06bde748f3f97925e4beb1dfe09f530435f651ee5223a4a8937bb7b7f755326bed59a2e12ef0e3782d85991a8ca5073a0d7a90c"
+                  "bytes": "15a848f5f7d4c5aba9076fbecf58f4c7bf8b6827d3cdfedf41f6c77d2b8d1bcef6f2163b9aa6f4068245a968af2cae1643710a480686d6f377b5327b0e1f0306"
                 }
               ]
             }
@@ -353,18 +379,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -403,18 +462,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -568,12 +660,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "52827f17c6f8c95b7748059d3e6a827c53f1c46631a0a7e9e6f7ac836ed9f669"
+                        "bytes": "72daf44779d92205fc2c541d85bade35c9b2477d209e1a556a484466ff849856"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_transfer_updates_owner.1.json
+++ b/clips_nft/test_snapshots/tests/test_transfer_updates_owner.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "22acd589ee83986769c4ab075a0333a0ccae45671b322ac356c5c2efa752cfb6"
+                  "bytes": "04220f8d33be11e5c0fca666d73cdd3d3b5c7638c893e5a65f9f2ce8ee0e1946"
                 }
               ]
             }
@@ -60,24 +60,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "febd7ed649ebe84014aefc32f6c8a9d4b801847c8000e0b8c3007c91ebad435c4625c1885cf0e4226d64f8381d3a54237a07cf765db6593d51dc79357ac5e90b"
+                  "bytes": "21413fdd39a92148a1d5d924abca135877ed695340134c7e87d7e01a6c0c2b7f9d442e9298bcfda881ce1539253666040a8e9879a42f8f150226f2f6e75b170c"
                 }
               ]
             }
@@ -265,18 +278,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -386,12 +432,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "22acd589ee83986769c4ab075a0333a0ccae45671b322ac356c5c2efa752cfb6"
+                        "bytes": "04220f8d33be11e5c0fca666d73cdd3d3b5c7638c893e5a65f9f2ce8ee0e1946"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_unpause_restores_mint_and_transfer.1.json
+++ b/clips_nft/test_snapshots/tests/test_unpause_restores_mint_and_transfer.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "cd9dd34fee2ddaa0262aac1f1dc00ece06c48ffd44f031f7a0180632c37cd60f"
+                  "bytes": "91925204402f0618de2f8a85be126ad5140b16dc0da23fe4860fe8872bab935a"
                 }
               ]
             }
@@ -99,24 +99,37 @@
                     },
                     {
                       "key": {
-                        "symbol": "basis_points"
+                        "symbol": "recipients"
                       },
                       "val": {
-                        "u32": 500
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "recipient"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "basis_points"
+                                },
+                                "val": {
+                                  "u32": 500
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "recipient"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
                 },
                 {
-                  "bytes": "a79a39db9fbc375509e1c32c4fb68ea7538748a6f8321291d9ca0cde0531c8321bb732e4c3398097d1eb62d1468b513c3dd7a66175fc791002e1b62a5036e20e"
+                  "bytes": "8368bfa47fb993322975599c8a501ea32b47859679fedec32bb31072cc4a0a148f470dda0276f740b7fea6dc68c66a386fd2c44682b9c2c3f5693b6bb4947509"
                 }
               ]
             }
@@ -344,18 +357,51 @@
                   },
                   {
                     "key": {
-                      "symbol": "basis_points"
+                      "symbol": "recipients"
                     },
                     "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "recipient"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 500
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "basis_points"
+                              },
+                              "val": {
+                                "u32": 100
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   }
                 ]
@@ -465,12 +511,24 @@
                       "key": {
                         "vec": [
                           {
+                            "symbol": "PlatformRecipient"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
                             "symbol": "Signer"
                           }
                         ]
                       },
                       "val": {
-                        "bytes": "cd9dd34fee2ddaa0262aac1f1dc00ece06c48ffd44f031f7a0180632c37cd60f"
+                        "bytes": "91925204402f0618de2f8a85be126ad5140b16dc0da23fe4860fe8872bab935a"
                       }
                     }
                   ]


### PR DESCRIPTION
Closes #12

## What changed
- migrated token royalty storage from single recipient to recipient arrays with basis-point splits
- added automatic default 1% platform royalty recipient when not supplied
- updated royalty calculations and payout flow to handle multi-recipient distributions

## Verification
- `cargo test`

Made with [Cursor](https://cursor.com)