### PR TITLE
[7] [Soroban] Add access control - only owner can mint

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -286,14 +286,13 @@ impl ClipsNftContract {
     /// * `signature`    - 64-byte Ed25519 signature from the backend signer
     pub fn mint(
         env: Env,
-        admin: Address,
         to: Address,
         clip_id: u32,
         metadata_uri: String,
         royalty: Royalty,
         signature: BytesN<64>,
     ) -> Result<TokenId, Error> {
-        Self::require_admin(&env, &admin)?;
+        to.require_auth();
         Self::require_not_paused(&env)?;
 
         // Verify backend signature before any state reads/writes
@@ -748,21 +747,13 @@ mod tests {
     fn do_mint(
         client: &ClipsNftContractClient,
         env: &Env,
-        admin: &Address,
         to: &Address,
         clip_id: u32,
         keypair: &ed25519_dalek::SigningKey,
     ) -> TokenId {
         let uri = String::from_str(env, "ipfs://QmExample");
         let sig = sign_mint(env, keypair, to, clip_id, &uri);
-        client.mint(
-            admin,
-            to,
-            &clip_id,
-            &uri,
-            &default_royalty(env, to.clone()),
-            &sig,
-        )
+        client.mint(to, &clip_id, &uri, &default_royalty(env, to.clone()), &sig)
     }
 
     #[test]
@@ -773,7 +764,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 42, &kp);
+        let token_id = do_mint(&client, &env, &user1, 42, &kp);
         assert_eq!(token_id, 1);
 
         assert_eq!(client.owner_of(&token_id), user1);
@@ -792,7 +783,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 99, &kp);
+        let token_id = do_mint(&client, &env, &user1, 99, &kp);
         assert_eq!(client.clip_token_id(&99), token_id);
     }
 
@@ -805,8 +796,8 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        do_mint(&client, &env, &admin, &user1, 7, &kp);
-        do_mint(&client, &env, &admin, &user1, 7, &kp);
+        do_mint(&client, &env, &user1, 7, &kp);
+        do_mint(&client, &env, &user1, 7, &kp);
     }
 
     #[test]
@@ -817,7 +808,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 5, &kp);
+        let token_id = do_mint(&client, &env, &user1, 5, &kp);
 
         let events = env.events().all();
         assert_eq!(events.events().len(), 1);
@@ -841,7 +832,7 @@ mod tests {
         let uri = String::from_str(&env, "ipfs://QmExample");
         let sig = sign_mint(&env, &kp, &user1, 1, &uri);
 
-        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig);
+        let result = client.try_mint(&user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig);
         assert_eq!(result, Err(Ok(Error::SignerNotSet)));
     }
 
@@ -861,7 +852,7 @@ mod tests {
         let bad_sig = sign_mint(&env, &wrong_kp, &user1, 1, &uri);
 
         // ed25519_verify traps on bad sig, which surfaces as a panic in tests
-        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &bad_sig);
+        client.mint(&user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &bad_sig);
     }
 
     #[test]
@@ -877,7 +868,7 @@ mod tests {
         // Signature is over user2 but we pass user1 as `to`
         let sig_for_user2 = sign_mint(&env, &kp, &user2, 1, &uri);
 
-        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig_for_user2);
+        client.mint(&user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig_for_user2);
     }
 
     #[test]
@@ -893,7 +884,7 @@ mod tests {
         // Signature is over clip_id=99 but we pass clip_id=1
         let sig_for_99 = sign_mint(&env, &kp, &user1, 99, &uri);
 
-        client.mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig_for_99);
+        client.mint(&user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig_for_99);
     }
 
     #[test]
@@ -917,7 +908,7 @@ mod tests {
         // Old signer's signature should now fail
         let uri = String::from_str(&env, "ipfs://QmExample");
         let old_sig = sign_mint(&env, &kp1, &user1, 1, &uri);
-        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &old_sig);
+        let result = client.try_mint(&user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &old_sig);
         assert!(result.is_err());
     }
 
@@ -933,7 +924,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id = do_mint(&client, &env, &user1, 1, &kp);
         client.transfer(&user1, &user2, &token_id);
 
         assert_eq!(client.owner_of(&token_id), user2);
@@ -948,9 +939,9 @@ mod tests {
         let kp = register_signer(&env, &client, &admin);
 
         assert_eq!(client.total_supply(), 0);
-        do_mint(&client, &env, &admin, &user1, 1, &kp);
+        do_mint(&client, &env, &user1, 1, &kp);
         assert_eq!(client.total_supply(), 1);
-        do_mint(&client, &env, &admin, &user1, 2, &kp);
+        do_mint(&client, &env, &user1, 2, &kp);
         assert_eq!(client.total_supply(), 2);
     }
 
@@ -962,7 +953,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id = do_mint(&client, &env, &user1, 1, &kp);
 
         let info = client.royalty_info(&token_id, &1_000_000i128);
         assert_eq!(info.royalty_amount, 60_000i128);
@@ -989,7 +980,7 @@ mod tests {
         };
         let uri = String::from_str(&env, "ipfs://QmCustom");
         let sig = sign_mint(&env, &kp, &user1, 2, &uri);
-        let token_id = client.mint(&admin, &user1, &2u32, &uri, &royalty, &sig);
+        let token_id = client.mint(&user1, &2u32, &uri, &royalty, &sig);
 
         let info = client.royalty_info(&token_id, &500i128);
         assert_eq!(info.royalty_amount, 55i128);
@@ -1004,7 +995,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id = do_mint(&client, &env, &user1, 1, &kp);
 
         let asset_addr = Address::generate(&env);
         let mut recipients = Vec::new(&env);
@@ -1033,12 +1024,12 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id = do_mint(&client, &env, &user1, 1, &kp);
         client.burn(&user1, &token_id);
 
         assert!(!client.exists(&token_id));
         // clip_id dedup entry also removed — can re-mint same clip_id
-        let token_id2 = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id2 = do_mint(&client, &env, &user1, 1, &kp);
         assert!(client.exists(&token_id2));
     }
 
@@ -1050,7 +1041,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 77, &kp);
+        let token_id = do_mint(&client, &env, &user1, 77, &kp);
         client.burn(&user1, &token_id);
 
         let events = env.events().all();
@@ -1071,7 +1062,7 @@ mod tests {
 
         let uri = String::from_str(&env, "ipfs://QmPaused");
         let sig = sign_mint(&env, &kp, &user1, 1, &uri);
-        let result = client.try_mint(&admin, &user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig);
+        let result = client.try_mint(&user1, &1u32, &uri, &default_royalty(&env, user1.clone()), &sig);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
     }
 
@@ -1083,7 +1074,7 @@ mod tests {
         client.init(&admin);
         let kp = register_signer(&env, &client, &admin);
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id = do_mint(&client, &env, &user1, 1, &kp);
         client.pause(&admin);
 
         let result = client.try_transfer(&user1, &user2, &token_id);
@@ -1102,7 +1093,7 @@ mod tests {
         client.unpause(&admin);
         assert!(!client.is_paused());
 
-        let token_id = do_mint(&client, &env, &admin, &user1, 1, &kp);
+        let token_id = do_mint(&client, &env, &user1, 1, &kp);
         client.transfer(&user1, &user2, &token_id);
         assert_eq!(client.owner_of(&token_id), user2);
     }

--- a/clips_nft/test_snapshots/tests/test_burn.1.json
+++ b/clips_nft/test_snapshots/tests/test_burn.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "d68cc9aa01caee7ed7ddecbd0aeb3ebc7eb00b01f2458295e90f29d7792705ca"
+                  "bytes": "4ac768d373d0ea3f09be587ef7803814f12cb4bf1b190c52350878381afe92d7"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "08ea3c8f7e9dba476c0dc476871e2e102b528bdcccfc196df36e61284132f88a3d9664286952372c0cd1db4605686c185fceadbc68c2fe60fe6391938441e607"
+                  "bytes": "f0e6dc45d890aed12d3b85c0152360292531c8176ea1fe0e4bd756d0ac0de8ae0bc35a8e6fb0f61cfeafd7264614b6ab215d5b1e4346b33ffa803b627669b209"
                 }
               ]
             }
@@ -124,16 +121,13 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -183,7 +177,7 @@
                   ]
                 },
                 {
-                  "bytes": "08ea3c8f7e9dba476c0dc476871e2e102b528bdcccfc196df36e61284132f88a3d9664286952372c0cd1db4605686c185fceadbc68c2fe60fe6391938441e607"
+                  "bytes": "f0e6dc45d890aed12d3b85c0152360292531c8176ea1fe0e4bd756d0ac0de8ae0bc35a8e6fb0f61cfeafd7264614b6ab215d5b1e4346b33ffa803b627669b209"
                 }
               ]
             }
@@ -230,30 +224,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "4837995959683129791"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "5541220902715666415"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -273,7 +247,27 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",
@@ -537,7 +531,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "d68cc9aa01caee7ed7ddecbd0aeb3ebc7eb00b01f2458295e90f29d7792705ca"
+                        "bytes": "4ac768d373d0ea3f09be587ef7803814f12cb4bf1b190c52350878381afe92d7"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_burn_emits_event.1.json
+++ b/clips_nft/test_snapshots/tests/test_burn_emits_event.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "30f419a98cf457969649fcde5c556ebe35d2740f3bcb380a764f54b51f11477e"
+                  "bytes": "227ff9191d85dd25f877699199d7b449af51f82c6d7ba654644ec480a403030e"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "46c50d847d669f1603344d080b55caff12585a042da2d030cbdca6528ece2652bc2943bf9238ac4c5f01ead70946fdeb18876ad3dd8339310a6fd207e0ac1904"
+                  "bytes": "586e5d5e9daa4046a80ea0d8bc9913d3e576b620f23ede1a8ac169aab38f9263db7dc2a6767d19cff762deb8cb9679b59c67716225714fb6ef325431fc5a830d"
                 }
               ]
             }
@@ -158,10 +155,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "5541220902715666415"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -181,7 +178,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",
@@ -264,7 +261,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "30f419a98cf457969649fcde5c556ebe35d2740f3bcb380a764f54b51f11477e"
+                        "bytes": "227ff9191d85dd25f877699199d7b449af51f82c6d7ba654644ec480a403030e"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_clip_token_id_lookup.1.json
+++ b/clips_nft/test_snapshots/tests/test_clip_token_id_lookup.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "fdadb14e47b7849970ea9ebd273d3c93032bf924e282af9d9ddc7ad024c860d5"
+                  "bytes": "8813038f43b48a7e59285d22f3cb17cc8a2f24b2168129f006d71653c749b868"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "0695f7d97f501e7d8b73ec5bcaf20acba375b4f5dbfe718bee49438d1ad0f236c45501283f059af9d66a3a7535ff436bf61aff6d2f5c1548c552dfa49ae0cc09"
+                  "bytes": "3dfae3d16ce8b7fa6aaacc549bd313c762e79987376948223892e9a59c29937eb6cc2fd7fdabc2ec1bcc645b5f7e1386608413965ecfa9d98bcb62de3df66508"
                 }
               ]
             }
@@ -137,7 +134,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -404,7 +401,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "fdadb14e47b7849970ea9ebd273d3c93032bf924e282af9d9ddc7ad024c860d5"
+                        "bytes": "8813038f43b48a7e59285d22f3cb17cc8a2f24b2168129f006d71653c749b868"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_double_mint_same_clip_id_panics.1.json
+++ b/clips_nft/test_snapshots/tests/test_double_mint_same_clip_id_panics.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "9bfc5ac4be487d076e49b3fee1ba5987d4b471a958aaa43a454146ea09380c85"
+                  "bytes": "8a1c1aeb9f981a5f1d00992fe31ff65d8622e873566c9bd46b984d3ca0651bdc"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "bc82bea03787576845ce46cdb499aee756da92011b7ecc5f636b0b32aed86eb6e842383e837d282c8393d0147f980333adab80cbf7943b331b93091f1660240e"
+                  "bytes": "8632737af3458a430bb18894ee0eabd3913b9c826ed84598221d096926abb1e44aad95b6eee1cc44b7e9bdd47c8da2b278bd7eee913d65cd96bbe7d50fd8360a"
                 }
               ]
             }
@@ -137,7 +134,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -404,7 +401,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "9bfc5ac4be487d076e49b3fee1ba5987d4b471a958aaa43a454146ea09380c85"
+                        "bytes": "8a1c1aeb9f981a5f1d00992fe31ff65d8622e873566c9bd46b984d3ca0651bdc"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_emits_event.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_emits_event.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "83a27ecd2b6b471a655e00415114e367625bf23364ddd44c53b1037b59df9c24"
+                  "bytes": "88dd1421fc83f7c3d9b941b9a4ba05182169f8773e0d7a78a813b98f9cc2eec9"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "9bc3acaf5aa0f39e6172b89fa3707317cd33ce38522d5499b239f1c635a8813d6a7e62a0ca142455439335fa1e7094e1b14f5a37afe58335fa59fdcd2500240f"
+                  "bytes": "589cb1521b2516048577fd9cd4844c408f0ec74c14b991d74266134f913c281dd14e38bbf764150be540f4742dcf2866c9305568c76ee97cc8fd3f9060722f0f"
                 }
               ]
             }
@@ -136,7 +133,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -403,7 +400,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "83a27ecd2b6b471a655e00415114e367625bf23364ddd44c53b1037b59df9c24"
+                        "bytes": "88dd1421fc83f7c3d9b941b9a4ba05182169f8773e0d7a78a813b98f9cc2eec9"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_clip_id_in_payload.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_clip_id_in_payload.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "287506615de6f1359d85f78d0ac89a83d9b4537ab3c9015c78432be07b611eae"
+                  "bytes": "5dd9fa8d503a97b837abed0e46f1838e30b25568cac7e670141ae9acdf39aaac"
                 }
               ]
             }
@@ -133,7 +133,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "287506615de6f1359d85f78d0ac89a83d9b4537ab3c9015c78432be07b611eae"
+                        "bytes": "5dd9fa8d503a97b837abed0e46f1838e30b25568cac7e670141ae9acdf39aaac"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_owner_in_payload.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_owner_in_payload.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "4eee95ea7d70f2693c80e057bd8be4102f502cd36c08e8b004939bdf912d67aa"
+                  "bytes": "08ec670a96855767d2434f39609a7ff9475f080115a5b3c810b4befeb62653ed"
                 }
               ]
             }
@@ -133,7 +133,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "4eee95ea7d70f2693c80e057bd8be4102f502cd36c08e8b004939bdf912d67aa"
+                        "bytes": "08ec670a96855767d2434f39609a7ff9475f080115a5b3c810b4befeb62653ed"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_signature.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_signature.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "33747c6733eea25d728dfaea2cb2832ef694d75eb321ab4076cdd1d48ddca957"
+                  "bytes": "2bd30ed651974da00fc4e42dec619224585d5a576645a60508df06afa74dd179"
                 }
               ]
             }
@@ -133,7 +133,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "33747c6733eea25d728dfaea2cb2832ef694d75eb321ab4076cdd1d48ddca957"
+                        "bytes": "2bd30ed651974da00fc4e42dec619224585d5a576645a60508df06afa74dd179"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_stores_owner_and_uri.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_stores_owner_and_uri.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "91a7317be0a1be4011cb5d77b1e6f9af1638d94fc136d7206b1246db926d02c3"
+                  "bytes": "b1fcf803783e316ed8a343224a531940ca09940555afd7ba65fa378de6e5eb5d"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "2965d16b11fc2682abe6ec9d4c26cafd8be174ca88437f152b6c28e26dc346144e6e5c3a60ea91fac96ec3935a105ee3b911110a8435a38ed38de161bc0db700"
+                  "bytes": "fecc40bbd3d73720acaed2d42020f8568ecef1ded5bde6a13724f88f681b290d6a586fe7654b99c6fbb5b9d651c35946a80366528ccd9ec6f165192032ab070c"
                 }
               ]
             }
@@ -139,7 +136,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -406,7 +403,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "91a7317be0a1be4011cb5d77b1e6f9af1638d94fc136d7206b1246db926d02c3"
+                        "bytes": "b1fcf803783e316ed8a343224a531940ca09940555afd7ba65fa378de6e5eb5d"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_pause_blocks_mint.1.json
+++ b/clips_nft/test_snapshots/tests/test_pause_blocks_mint.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "65c3a148fcf510773f9e458ea0724ae6e4316213fc8810cba61a23296567ce15"
+                  "bytes": "c8f654debdd8ca32b404c7a326e6635f382e6ed5e70cad67dd442b6e57f9c56f"
                 }
               ]
             }
@@ -174,7 +174,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "65c3a148fcf510773f9e458ea0724ae6e4316213fc8810cba61a23296567ce15"
+                        "bytes": "c8f654debdd8ca32b404c7a326e6635f382e6ed5e70cad67dd442b6e57f9c56f"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_pause_blocks_transfer.1.json
+++ b/clips_nft/test_snapshots/tests/test_pause_blocks_transfer.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "14396847b9662bbf445636a470ed03d3d5204ebd3ec068cd18330a4d7bfd8452"
+                  "bytes": "075f61b378098b9bf255765e23014f86ca132e6cf2898d8021195956e77a38b3"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "eb3d8e75b8629b2af90ba395e3a27e4f1a0a40f6292f001256997d1e2de45cb1c5d414439866cee81cc71a322206ccacdc2db0127ec1bdccf1c3443966fdff0b"
+                  "bytes": "7ba366a7f687b57229d36ebdf87346c1b1a7637b50eff2f90b43ad368d52ea04c5fe975973ceef6c08041565d849e969422373d507dec6bb65bd7230e1e5470d"
                 }
               ]
             }
@@ -176,7 +173,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -443,7 +440,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "14396847b9662bbf445636a470ed03d3d5204ebd3ec068cd18330a4d7bfd8452"
+                        "bytes": "075f61b378098b9bf255765e23014f86ca132e6cf2898d8021195956e77a38b3"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_royalty_info_custom_asset.1.json
+++ b/clips_nft/test_snapshots/tests/test_royalty_info_custom_asset.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "ab1cd75c7dd2ee5b25e2fe5693a0883ea4e994cf56fee8235ac15374dfc0352a"
+                  "bytes": "eb6fc00d5296a5d128e684919d9d1c55d8df4ae36d7e9419e221da641b1f289b"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -92,7 +89,7 @@
                   ]
                 },
                 {
-                  "bytes": "37cd14eae130fb98e2067735a32f8ab23b7a4b9755449bac709e288f4897d1fc7616586542c5206f40c9349fe93510b465aafbaa14f119b82421e7c4c5ccf408"
+                  "bytes": "68bed9beb47abe6465b7b9920e47beee5833fc579a71db457c3fe4d02442fcd7fefe43b329babed9b191923252ba33a590323d1952710f2d494b1da0f967470c"
                 }
               ]
             }
@@ -139,7 +136,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -408,7 +405,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "ab1cd75c7dd2ee5b25e2fe5693a0883ea4e994cf56fee8235ac15374dfc0352a"
+                        "bytes": "eb6fc00d5296a5d128e684919d9d1c55d8df4ae36d7e9419e221da641b1f289b"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_royalty_info_xlm.1.json
+++ b/clips_nft/test_snapshots/tests/test_royalty_info_xlm.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "208ae447691fcf3e4a2d8d1951afe86a515f2118d55d0301407adcfa91f8e6b8"
+                  "bytes": "6a13127cadf8043c43ca4d8bee3962a4c4903efc170709c08dcbf60ff1f83067"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "17f230fc88bdfe148fafa31ef09f240b6ed0f39dee2b352d00d408d4985f6cb664b76fc8156716b03927a60b1174b5ca04b5f73b1679de8f4c567bb33795b308"
+                  "bytes": "70b38bb85e98ce7b7602d22f0e74421a07188b08fe35f0bca860ebe1ebcae474f31d4c5a1221e0769116cf2e7add07ef5dd2c63efb0f50a0a25bcbc44e35ef02"
                 }
               ]
             }
@@ -137,7 +134,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -404,7 +401,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "208ae447691fcf3e4a2d8d1951afe86a515f2118d55d0301407adcfa91f8e6b8"
+                        "bytes": "6a13127cadf8043c43ca4d8bee3962a4c4903efc170709c08dcbf60ff1f83067"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_set_royalty_with_custom_asset.1.json
+++ b/clips_nft/test_snapshots/tests/test_set_royalty_with_custom_asset.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "5f8d7c84f95a363280d3183fbba68fdbcbe9eca5575d53188342cf108f574925"
+                  "bytes": "925ca9f43883b2e37c15000189294d1b7484b3e803568064351b808b6decc134"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "f8c0d1688cadceed6198263cf30e6f3ab6eb6910d2089bce36d8cd3c9cae5ec04362632ac113ef5b71638fd1f7b617e4f29058b82d7b39ab54dbd6a7e067b300"
+                  "bytes": "4438f54b911239b38f2eff2f004118706768f87c2b56c0d92dc584e047b65a6d88797a859204cf2ad368377a2739617b1d9b5d4809ff1ef661f389d694c8410e"
                 }
               ]
             }
@@ -220,7 +217,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -489,7 +486,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "5f8d7c84f95a363280d3183fbba68fdbcbe9eca5575d53188342cf108f574925"
+                        "bytes": "925ca9f43883b2e37c15000189294d1b7484b3e803568064351b808b6decc134"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_set_signer_and_rotate.1.json
+++ b/clips_nft/test_snapshots/tests/test_set_signer_and_rotate.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "1130b895272cd9dfdcc15006b5ff98eb0c0bf200a4ea6b05b47deaf5194d3c16"
+                  "bytes": "2723754a0a666744292b8f624a3a2213abdeb8820f43f54e7564bef4d094c953"
                 }
               ]
             }
@@ -43,7 +43,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "de0a9a0b3f7d4017416578426ddcdad2a6570a9aa81c4b1afe45cb8844fe6952"
+                  "bytes": "585492bc755f6fca0107686fc1db12bab1ea1a029966ef1936cd037433518750"
                 }
               ]
             }
@@ -177,7 +177,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "de0a9a0b3f7d4017416578426ddcdad2a6570a9aa81c4b1afe45cb8844fe6952"
+                        "bytes": "585492bc755f6fca0107686fc1db12bab1ea1a029966ef1936cd037433518750"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_total_supply_derived_from_next_token_id.1.json
+++ b/clips_nft/test_snapshots/tests/test_total_supply_derived_from_next_token_id.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "72daf44779d92205fc2c541d85bade35c9b2477d209e1a556a484466ff849856"
+                  "bytes": "a63f115e30a27cab1fa5b72a467daab524d38a8768104945dadae5b9cceaf7c9"
                 }
               ]
             }
@@ -32,16 +32,13 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -91,7 +88,7 @@
                   ]
                 },
                 {
-                  "bytes": "c356c1286b058a95dd684c2a682c921a23c872d32ee0d347602d697bda4b622374ec4560c0ebb5eb13eb2d0bf9635eab0399617d1bf952de585d5a6ed3e9c708"
+                  "bytes": "ae86fba47cdbaa5ee9e4e00761fd862d9313cd956e0f73f6a120c9392ab553c7d417943d1677f3b45f758ffbe1e921498ddaa99b317a9acce3bce8d64984b90c"
                 }
               ]
             }
@@ -103,16 +100,13 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -162,7 +156,7 @@
                   ]
                 },
                 {
-                  "bytes": "15a848f5f7d4c5aba9076fbecf58f4c7bf8b6827d3cdfedf41f6c77d2b8d1bcef6f2163b9aa6f4068245a968af2cae1643710a480686d6f377b5327b0e1f0306"
+                  "bytes": "2e1dc3ea22187564a36e4743dba26a4cb571aa5e2dc0bae81995891c66ab198542158551ae2e18a4eb742a2d82ae59a0780978f6ac17919317bf14d2d6a0630f"
                 }
               ]
             }
@@ -209,7 +203,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "1033654523790656264"
@@ -229,7 +223,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
@@ -677,7 +671,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "72daf44779d92205fc2c541d85bade35c9b2477d209e1a556a484466ff849856"
+                        "bytes": "a63f115e30a27cab1fa5b72a467daab524d38a8768104945dadae5b9cceaf7c9"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_transfer_updates_owner.1.json
+++ b/clips_nft/test_snapshots/tests/test_transfer_updates_owner.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "04220f8d33be11e5c0fca666d73cdd3d3b5c7638c893e5a65f9f2ce8ee0e1946"
+                  "bytes": "b9f5186cd77352143f45ba7a0b0beaaef6a58e7d6bafb135d2a500f564935a0a"
                 }
               ]
             }
@@ -31,16 +31,13 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -90,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "21413fdd39a92148a1d5d924abca135877ed695340134c7e87d7e01a6c0c2b7f9d442e9298bcfda881ce1539253666040a8e9879a42f8f150226f2f6e75b170c"
+                  "bytes": "53f145b918617bc8a7e68422c1486f15f096966df45ee3f52baeb93b9bb2b412be85ff60093e655b99c96f8c79cab95713dd1f79a7504327a7a5eaf27a20f109"
                 }
               ]
             }
@@ -162,10 +159,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "5541220902715666415"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -185,7 +182,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",
@@ -449,7 +446,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "04220f8d33be11e5c0fca666d73cdd3d3b5c7638c893e5a65f9f2ce8ee0e1946"
+                        "bytes": "b9f5186cd77352143f45ba7a0b0beaaef6a58e7d6bafb135d2a500f564935a0a"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_unpause_restores_mint_and_transfer.1.json
+++ b/clips_nft/test_snapshots/tests/test_unpause_restores_mint_and_transfer.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "91925204402f0618de2f8a85be126ad5140b16dc0da23fe4860fe8872bab935a"
+                  "bytes": "b0900a32f1f47474e65dde3a8a7a81ec1a29a2845cd35e7018890ccafc26a712"
                 }
               ]
             }
@@ -70,16 +70,13 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "mint",
               "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
@@ -129,7 +126,7 @@
                   ]
                 },
                 {
-                  "bytes": "8368bfa47fb993322975599c8a501ea32b47859679fedec32bb31072cc4a0a148f470dda0276f740b7fea6dc68c66a386fd2c44682b9c2c3f5693b6bb4947509"
+                  "bytes": "c3579ec70e068cb8fcd3e01b32bde7005be7f7698cf44346b4442219ed69309ad2ff0aef361df9ab648bb57ebf4f34e34d1379d4c1451e8c1ee80e3b5dfdaf03"
                 }
               ]
             }
@@ -224,26 +221,6 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "4837995959683129791"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -265,6 +242,26 @@
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "2032731177588607455"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
                 }
               },
               "durability": "temporary",
@@ -528,7 +525,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "91925204402f0618de2f8a85be126ad5140b16dc0da23fe4860fe8872bab935a"
+                        "bytes": "b0900a32f1f47474e65dde3a8a7a81ec1a29a2845cd35e7018890ccafc26a712"
                       }
                     }
                   ]


### PR DESCRIPTION
Closes #7

## What changed
- removed admin-gated mint access control and required owner wallet auth (`to.require_auth()`) for mint execution
- preserved backend signature verification to ensure clip_id/owner/metadata payload integrity
- updated tests and snapshots for owner-auth mint flow

## Verification
- `cargo test`

