### PR TITLE
[10] [Soroban] Add events for mint, transfer, and royalty paid

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -193,6 +193,25 @@ pub struct BurnEvent {
     pub clip_id: u32,
 }
 
+/// Event emitted when NFT ownership changes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransferEvent {
+    pub token_id: TokenId,
+    pub from: Address,
+    pub to: Address,
+}
+
+/// Event emitted when royalty is paid.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoyaltyPaidEvent {
+    pub token_id: TokenId,
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+}
+
 /// NFT Contract
 #[contract]
 pub struct ClipsNftContract;
@@ -278,7 +297,6 @@ impl ClipsNftContract {
     /// Instance writes: NextTokenId = **1**
     ///
     /// # Arguments
-    /// * `admin`        - Must be the contract admin
     /// * `to`           - Address that will own the NFT (must match the signed payload)
     /// * `clip_id`      - Unique off-chain clip identifier (must match the signed payload)
     /// * `metadata_uri` - IPFS or Arweave URI (must match the signed payload)
@@ -367,8 +385,12 @@ impl ClipsNftContract {
         }
 
         // 1 persistent write — update owner in-place, clip_id unchanged
-        data.owner = to;
+        data.owner = to.clone();
         env.storage().persistent().set(&DataKey::Token(token_id), &data);
+        env.events().publish(
+            (symbol_short!("transfer"),),
+            TransferEvent { token_id, from, to },
+        );
 
         Ok(())
     }
@@ -500,7 +522,12 @@ impl ClipsNftContract {
             token_client.transfer(&payer, &split.recipient, &amount);
             env.events().publish(
                 (symbol_short!("royalty"),),
-                (token_id, split.recipient, amount, asset_address.clone()),
+                RoyaltyPaidEvent {
+                    token_id,
+                    from: payer.clone(),
+                    to: split.recipient,
+                    amount,
+                },
             );
         }
 
@@ -928,6 +955,21 @@ mod tests {
         client.transfer(&user1, &user2, &token_id);
 
         assert_eq!(client.owner_of(&token_id), user2);
+    }
+
+    #[test]
+    fn test_transfer_emits_event() {
+        let (env, admin, user1, user2) = setup();
+        let contract_id = env.register(ClipsNftContract, ());
+        let client = ClipsNftContractClient::new(&env, &contract_id);
+        client.init(&admin);
+        let kp = register_signer(&env, &client, &admin);
+
+        let token_id = do_mint(&client, &env, &user1, 3, &kp);
+        client.transfer(&user1, &user2, &token_id);
+
+        let events = env.events().all();
+        assert_eq!(events.events().len(), 1);
     }
 
     #[test]

--- a/clips_nft/test_snapshots/tests/test_burn.1.json
+++ b/clips_nft/test_snapshots/tests/test_burn.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "4ac768d373d0ea3f09be587ef7803814f12cb4bf1b190c52350878381afe92d7"
+                  "bytes": "1674a670506f402cbe7f50b82397be6c05a684081dc9d11f13da9f0dc304086e"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "f0e6dc45d890aed12d3b85c0152360292531c8176ea1fe0e4bd756d0ac0de8ae0bc35a8e6fb0f61cfeafd7264614b6ab215d5b1e4346b33ffa803b627669b209"
+                  "bytes": "b1f096e9933b5e7a0c843388055da094d2eaf77c8c86eaec3526611c598bdbcdd331f459a3ba88fa98de837bf8fc08290ed2356d96700d32cb697d8dc2340c0c"
                 }
               ]
             }
@@ -177,7 +177,7 @@
                   ]
                 },
                 {
-                  "bytes": "f0e6dc45d890aed12d3b85c0152360292531c8176ea1fe0e4bd756d0ac0de8ae0bc35a8e6fb0f61cfeafd7264614b6ab215d5b1e4346b33ffa803b627669b209"
+                  "bytes": "b1f096e9933b5e7a0c843388055da094d2eaf77c8c86eaec3526611c598bdbcdd331f459a3ba88fa98de837bf8fc08290ed2356d96700d32cb697d8dc2340c0c"
                 }
               ]
             }
@@ -531,7 +531,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "4ac768d373d0ea3f09be587ef7803814f12cb4bf1b190c52350878381afe92d7"
+                        "bytes": "1674a670506f402cbe7f50b82397be6c05a684081dc9d11f13da9f0dc304086e"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_burn_emits_event.1.json
+++ b/clips_nft/test_snapshots/tests/test_burn_emits_event.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "227ff9191d85dd25f877699199d7b449af51f82c6d7ba654644ec480a403030e"
+                  "bytes": "62a8dcae33141466fe436545906b56b2afb70a67d5f16a7ec2a3124402334ca4"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "586e5d5e9daa4046a80ea0d8bc9913d3e576b620f23ede1a8ac169aab38f9263db7dc2a6767d19cff762deb8cb9679b59c67716225714fb6ef325431fc5a830d"
+                  "bytes": "3bbf288aa7d888643cc176b3889dddc23be48098b3ac58ab89c39eb6c4df412b170b6bddabb84afd9fefebb7e1abc3b4443f4d8afbf4baddd78bd6e320a57005"
                 }
               ]
             }
@@ -261,7 +261,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "227ff9191d85dd25f877699199d7b449af51f82c6d7ba654644ec480a403030e"
+                        "bytes": "62a8dcae33141466fe436545906b56b2afb70a67d5f16a7ec2a3124402334ca4"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_clip_token_id_lookup.1.json
+++ b/clips_nft/test_snapshots/tests/test_clip_token_id_lookup.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "8813038f43b48a7e59285d22f3cb17cc8a2f24b2168129f006d71653c749b868"
+                  "bytes": "8a9a29b97c42c46ab310f7e9b92d65db0ec8d081769279f5306f2bc82e7b024d"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "3dfae3d16ce8b7fa6aaacc549bd313c762e79987376948223892e9a59c29937eb6cc2fd7fdabc2ec1bcc645b5f7e1386608413965ecfa9d98bcb62de3df66508"
+                  "bytes": "dc0ee833f3a937d813eda191eac740a719243e385dc4ac8d270a873dfa12a988c4586b3661a15fc9fadd838c439857de8d15d41245d81a6b790fade950c8010d"
                 }
               ]
             }
@@ -401,7 +401,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "8813038f43b48a7e59285d22f3cb17cc8a2f24b2168129f006d71653c749b868"
+                        "bytes": "8a9a29b97c42c46ab310f7e9b92d65db0ec8d081769279f5306f2bc82e7b024d"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_double_mint_same_clip_id_panics.1.json
+++ b/clips_nft/test_snapshots/tests/test_double_mint_same_clip_id_panics.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "8a1c1aeb9f981a5f1d00992fe31ff65d8622e873566c9bd46b984d3ca0651bdc"
+                  "bytes": "e50e7b46c1c08ee105decaf1d1a818c528dccceecd04d83c15ee9b1101085700"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "8632737af3458a430bb18894ee0eabd3913b9c826ed84598221d096926abb1e44aad95b6eee1cc44b7e9bdd47c8da2b278bd7eee913d65cd96bbe7d50fd8360a"
+                  "bytes": "a9014f71c8d051e309467400b1d0935798f55228dbe35fdbe2cb66bf893cdfed7fb87808e3f39d439c85790d4da48f31d003a2765eedac6783e9ff608f5c8001"
                 }
               ]
             }
@@ -401,7 +401,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "8a1c1aeb9f981a5f1d00992fe31ff65d8622e873566c9bd46b984d3ca0651bdc"
+                        "bytes": "e50e7b46c1c08ee105decaf1d1a818c528dccceecd04d83c15ee9b1101085700"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_clip_id_in_payload.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_clip_id_in_payload.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "5dd9fa8d503a97b837abed0e46f1838e30b25568cac7e670141ae9acdf39aaac"
+                  "bytes": "9b88f31d617bd5063e1b278306e064dd4a0a49950d2abe938362e1996f1bdb90"
                 }
               ]
             }
@@ -133,7 +133,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "5dd9fa8d503a97b837abed0e46f1838e30b25568cac7e670141ae9acdf39aaac"
+                        "bytes": "9b88f31d617bd5063e1b278306e064dd4a0a49950d2abe938362e1996f1bdb90"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_owner_in_payload.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_owner_in_payload.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "08ec670a96855767d2434f39609a7ff9475f080115a5b3c810b4befeb62653ed"
+                  "bytes": "578e89f26a73ba6de21efabca8e945862b9a90c3a3283c69a8fbe9a2d9bbba3a"
                 }
               ]
             }
@@ -133,7 +133,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "08ec670a96855767d2434f39609a7ff9475f080115a5b3c810b4befeb62653ed"
+                        "bytes": "578e89f26a73ba6de21efabca8e945862b9a90c3a3283c69a8fbe9a2d9bbba3a"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_signature.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_fails_with_wrong_signature.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "2bd30ed651974da00fc4e42dec619224585d5a576645a60508df06afa74dd179"
+                  "bytes": "752fb04d194b9864385205a80339c55b60d0d2ee2bee83e3777e8cdfcb891369"
                 }
               ]
             }
@@ -133,7 +133,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "2bd30ed651974da00fc4e42dec619224585d5a576645a60508df06afa74dd179"
+                        "bytes": "752fb04d194b9864385205a80339c55b60d0d2ee2bee83e3777e8cdfcb891369"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_mint_stores_owner_and_uri.1.json
+++ b/clips_nft/test_snapshots/tests/test_mint_stores_owner_and_uri.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "b1fcf803783e316ed8a343224a531940ca09940555afd7ba65fa378de6e5eb5d"
+                  "bytes": "ebaab1ea2041fc218f86ebbeb3ef008f73bccd405e324cf21b267600e87719f3"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "fecc40bbd3d73720acaed2d42020f8568ecef1ded5bde6a13724f88f681b290d6a586fe7654b99c6fbb5b9d651c35946a80366528ccd9ec6f165192032ab070c"
+                  "bytes": "1038d30b7cff2d98db44d78e0083828c28702113c6b36b1619c3111f3af288ac9201a2fa10c7653bf6d5aff3cb8fa9fb82fdbda3f90402338528cf9fc2a82009"
                 }
               ]
             }
@@ -403,7 +403,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "b1fcf803783e316ed8a343224a531940ca09940555afd7ba65fa378de6e5eb5d"
+                        "bytes": "ebaab1ea2041fc218f86ebbeb3ef008f73bccd405e324cf21b267600e87719f3"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_pause_blocks_mint.1.json
+++ b/clips_nft/test_snapshots/tests/test_pause_blocks_mint.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "c8f654debdd8ca32b404c7a326e6635f382e6ed5e70cad67dd442b6e57f9c56f"
+                  "bytes": "d74d91e910e7ef40c5b5212ff0a91f17d93e3638da1db448bbb808b83da66fe1"
                 }
               ]
             }
@@ -174,7 +174,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "c8f654debdd8ca32b404c7a326e6635f382e6ed5e70cad67dd442b6e57f9c56f"
+                        "bytes": "d74d91e910e7ef40c5b5212ff0a91f17d93e3638da1db448bbb808b83da66fe1"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_pause_blocks_transfer.1.json
+++ b/clips_nft/test_snapshots/tests/test_pause_blocks_transfer.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "075f61b378098b9bf255765e23014f86ca132e6cf2898d8021195956e77a38b3"
+                  "bytes": "b108930df61b416057013163d89f5620a36187e502ad70210ce049125a514627"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "7ba366a7f687b57229d36ebdf87346c1b1a7637b50eff2f90b43ad368d52ea04c5fe975973ceef6c08041565d849e969422373d507dec6bb65bd7230e1e5470d"
+                  "bytes": "cbbdae508cd0ea19117441f70dca64c8bcd03503241731138f68a00198864527c0ab5d68ff7d098f7d0f5006cc84f99526eb33b99fb916d3dd70dc114713ba03"
                 }
               ]
             }
@@ -440,7 +440,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "075f61b378098b9bf255765e23014f86ca132e6cf2898d8021195956e77a38b3"
+                        "bytes": "b108930df61b416057013163d89f5620a36187e502ad70210ce049125a514627"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_royalty_info_custom_asset.1.json
+++ b/clips_nft/test_snapshots/tests/test_royalty_info_custom_asset.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "eb6fc00d5296a5d128e684919d9d1c55d8df4ae36d7e9419e221da641b1f289b"
+                  "bytes": "c3fc45c3d3bb41507ae74bcd8ce3da0b6f60cfd33ea429748d83bf56e6726361"
                 }
               ]
             }
@@ -89,7 +89,7 @@
                   ]
                 },
                 {
-                  "bytes": "68bed9beb47abe6465b7b9920e47beee5833fc579a71db457c3fe4d02442fcd7fefe43b329babed9b191923252ba33a590323d1952710f2d494b1da0f967470c"
+                  "bytes": "7071c26360dbcc5fd474f6431add0b1d2dcc19d2bc3c7b6a27268b443c7e2e5eeb55947ed257d07077db1525c4c72c3e8d9047be67464f4a4fe066f1cd259703"
                 }
               ]
             }
@@ -405,7 +405,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "eb6fc00d5296a5d128e684919d9d1c55d8df4ae36d7e9419e221da641b1f289b"
+                        "bytes": "c3fc45c3d3bb41507ae74bcd8ce3da0b6f60cfd33ea429748d83bf56e6726361"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_royalty_info_xlm.1.json
+++ b/clips_nft/test_snapshots/tests/test_royalty_info_xlm.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "6a13127cadf8043c43ca4d8bee3962a4c4903efc170709c08dcbf60ff1f83067"
+                  "bytes": "d4c21c4fa91c95eb50f0e787259bf2ce7840d097b7da473d0ed27b00ad95c873"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "70b38bb85e98ce7b7602d22f0e74421a07188b08fe35f0bca860ebe1ebcae474f31d4c5a1221e0769116cf2e7add07ef5dd2c63efb0f50a0a25bcbc44e35ef02"
+                  "bytes": "6f6c655a9117576fc11714baee6e13773c3f9aa554263d177c0a1943d62ec9865fe86909c0994059b07287ba08ae8a1eb27b9c9a8c8b4e8ad648d2c1432cbe04"
                 }
               ]
             }
@@ -401,7 +401,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "6a13127cadf8043c43ca4d8bee3962a4c4903efc170709c08dcbf60ff1f83067"
+                        "bytes": "d4c21c4fa91c95eb50f0e787259bf2ce7840d097b7da473d0ed27b00ad95c873"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_set_royalty_with_custom_asset.1.json
+++ b/clips_nft/test_snapshots/tests/test_set_royalty_with_custom_asset.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "925ca9f43883b2e37c15000189294d1b7484b3e803568064351b808b6decc134"
+                  "bytes": "e6ac247b2729d0afca6da11d0b080fc4afbf189e8be523b6f799507bd606c339"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "4438f54b911239b38f2eff2f004118706768f87c2b56c0d92dc584e047b65a6d88797a859204cf2ad368377a2739617b1d9b5d4809ff1ef661f389d694c8410e"
+                  "bytes": "09868c98c88c6f2962e6a67cd7331019db9543c236fb32e4381370c65557fdd408b6a7cabee0acbd350e22017aadc75a41ab589ad06d57cc9b812d3069fcdd05"
                 }
               ]
             }
@@ -486,7 +486,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "925ca9f43883b2e37c15000189294d1b7484b3e803568064351b808b6decc134"
+                        "bytes": "e6ac247b2729d0afca6da11d0b080fc4afbf189e8be523b6f799507bd606c339"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_set_signer_and_rotate.1.json
+++ b/clips_nft/test_snapshots/tests/test_set_signer_and_rotate.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "2723754a0a666744292b8f624a3a2213abdeb8820f43f54e7564bef4d094c953"
+                  "bytes": "4a7500befbe69b697a3dcfaf1853b8f46abc4e24bb99bf65f2aa51a4d30dcfd0"
                 }
               ]
             }
@@ -43,7 +43,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "585492bc755f6fca0107686fc1db12bab1ea1a029966ef1936cd037433518750"
+                  "bytes": "53a7d73013a69bb0fac203059d4790af4e8c78522689fbe1ff42a61f14c82ee0"
                 }
               ]
             }
@@ -177,7 +177,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "585492bc755f6fca0107686fc1db12bab1ea1a029966ef1936cd037433518750"
+                        "bytes": "53a7d73013a69bb0fac203059d4790af4e8c78522689fbe1ff42a61f14c82ee0"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_total_supply_derived_from_next_token_id.1.json
+++ b/clips_nft/test_snapshots/tests/test_total_supply_derived_from_next_token_id.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "a63f115e30a27cab1fa5b72a467daab524d38a8768104945dadae5b9cceaf7c9"
+                  "bytes": "0d26b6d45bc5c170706b27a92638c91bdfccef0cfe05e71dfcbd8ef799ec16d8"
                 }
               ]
             }
@@ -88,7 +88,7 @@
                   ]
                 },
                 {
-                  "bytes": "ae86fba47cdbaa5ee9e4e00761fd862d9313cd956e0f73f6a120c9392ab553c7d417943d1677f3b45f758ffbe1e921498ddaa99b317a9acce3bce8d64984b90c"
+                  "bytes": "8bff905c8a8e0ec911919796462b8be84cbeca2e517d3d63bd386ad999a3ead509cbfb8a0a2740092c34455f3d57965726144e5dfab0b414f70bfbaf89c4e30c"
                 }
               ]
             }
@@ -156,7 +156,7 @@
                   ]
                 },
                 {
-                  "bytes": "2e1dc3ea22187564a36e4743dba26a4cb571aa5e2dc0bae81995891c66ab198542158551ae2e18a4eb742a2d82ae59a0780978f6ac17919317bf14d2d6a0630f"
+                  "bytes": "2ce44c708ebbedfd88e10e3e3dd7a45b12a7e122f34cc6d172ed6bb994ea7d53f841b278e48952cfdec1ce6f2fac8f35e93ded0e5e7938f5e80d1ff9edbcb30d"
                 }
               ]
             }
@@ -671,7 +671,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "a63f115e30a27cab1fa5b72a467daab524d38a8768104945dadae5b9cceaf7c9"
+                        "bytes": "0d26b6d45bc5c170706b27a92638c91bdfccef0cfe05e71dfcbd8ef799ec16d8"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_transfer_emits_event.1.json
+++ b/clips_nft/test_snapshots/tests/test_transfer_emits_event.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "4944bbabd59fcf2a5fdfbb6a7bfebd990615cd5935cf2c1d55b7ee2c980e1737"
+                  "bytes": "2753ee1654efbbb54a16ae7ead18d33201c39f8aa0ddb8c880085c8c1529565a"
                 }
               ]
             }
@@ -42,7 +42,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "u32": 5
+                  "u32": 3
                 },
                 {
                   "string": "ipfs://QmExample"
@@ -87,7 +87,32 @@
                   ]
                 },
                 {
-                  "bytes": "27ce878f29beafa6687ab023f6cce36162df1e4f5f6412c3ec6c883581443ca5954b6481528fb2a000900a821671eced3c21135f3676f3c5f14edf9be716820a"
+                  "bytes": "bb7237b6e5feca511ff704de4a72d08ab23a5371ff7472441bfd425ca644f2463ea4bdb60af91e4f4cccaf831b0579d3c4cba8ac16cbe1331a1a6f7a31189304"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u32": 1
                 }
               ]
             }
@@ -136,6 +161,26 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
                   "nonce": "5541220902715666415"
                 }
               },
@@ -160,7 +205,7 @@
                     "symbol": "ClipIdMinted"
                   },
                   {
-                    "u32": 5
+                    "u32": 3
                   }
                 ]
               },
@@ -309,7 +354,7 @@
                       "symbol": "clip_id"
                     },
                     "val": {
-                      "u32": 5
+                      "u32": 3
                     }
                   },
                   {
@@ -317,7 +362,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   }
                 ]
@@ -400,7 +445,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "4944bbabd59fcf2a5fdfbb6a7bfebd990615cd5935cf2c1d55b7ee2c980e1737"
+                        "bytes": "2753ee1654efbbb54a16ae7ead18d33201c39f8aa0ddb8c880085c8c1529565a"
                       }
                     }
                   ]
@@ -438,25 +483,17 @@
           "v0": {
             "topics": [
               {
-                "symbol": "mint"
+                "symbol": "transfer"
               }
             ],
             "data": {
               "map": [
                 {
                   "key": {
-                    "symbol": "clip_id"
+                    "symbol": "from"
                   },
                   "val": {
-                    "u32": 5
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "metadata_uri"
-                  },
-                  "val": {
-                    "string": "ipfs://QmExample"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                   }
                 },
                 {
@@ -464,7 +501,7 @@
                     "symbol": "to"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   }
                 },
                 {

--- a/clips_nft/test_snapshots/tests/test_transfer_updates_owner.1.json
+++ b/clips_nft/test_snapshots/tests/test_transfer_updates_owner.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "b9f5186cd77352143f45ba7a0b0beaaef6a58e7d6bafb135d2a500f564935a0a"
+                  "bytes": "9f91d4c4c47b2a7e142bbf250a1c4db7f02887d8a0abf104fc9c712462a5c705"
                 }
               ]
             }
@@ -87,7 +87,7 @@
                   ]
                 },
                 {
-                  "bytes": "53f145b918617bc8a7e68422c1486f15f096966df45ee3f52baeb93b9bb2b412be85ff60093e655b99c96f8c79cab95713dd1f79a7504327a7a5eaf27a20f109"
+                  "bytes": "f597a233f71ed216e438cb3177a0525cfa03d425dea32b5506b7b65d8ba73967e4e587a22d51ccec6510e85e2692cc074036e86ab35083f2e7e4f1302675b70a"
                 }
               ]
             }
@@ -446,7 +446,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "b9f5186cd77352143f45ba7a0b0beaaef6a58e7d6bafb135d2a500f564935a0a"
+                        "bytes": "9f91d4c4c47b2a7e142bbf250a1c4db7f02887d8a0abf104fc9c712462a5c705"
                       }
                     }
                   ]

--- a/clips_nft/test_snapshots/tests/test_unpause_restores_mint_and_transfer.1.json
+++ b/clips_nft/test_snapshots/tests/test_unpause_restores_mint_and_transfer.1.json
@@ -20,7 +20,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "bytes": "b0900a32f1f47474e65dde3a8a7a81ec1a29a2845cd35e7018890ccafc26a712"
+                  "bytes": "615cfa62496983c102a75a829c451e67e836973a4360b67f4386c8bcfeaed454"
                 }
               ]
             }
@@ -126,7 +126,7 @@
                   ]
                 },
                 {
-                  "bytes": "c3579ec70e068cb8fcd3e01b32bde7005be7f7698cf44346b4442219ed69309ad2ff0aef361df9ab648bb57ebf4f34e34d1379d4c1451e8c1ee80e3b5dfdaf03"
+                  "bytes": "36752aa34cd609464c1c0d1a91dae50223796e704c5257a0d3acf2400a49355e211dc9c1ef320f9243d132debb0226ee9ad185b5e2d9eb7e1a3503b8e4f62e0a"
                 }
               ]
             }
@@ -525,7 +525,7 @@
                         ]
                       },
                       "val": {
-                        "bytes": "b0900a32f1f47474e65dde3a8a7a81ec1a29a2845cd35e7018890ccafc26a712"
+                        "bytes": "615cfa62496983c102a75a829c451e67e836973a4360b67f4386c8bcfeaed454"
                       }
                     }
                   ]


### PR DESCRIPTION
Closes #10

## What changed
- recreated the event-focused branch on latest upstream main after previous PR closure
- kept typed transfer and royalty-paid event payloads with indexed fields
- added/updated transfer-event tests and snapshots for current owner-auth mint flow

## Verification
- `cargo test`

Made with [Cursor](https://cursor.com)