### PR TITLE
feat: emit RoyaltyRecipientUpdated event on royalty recipient change

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -1756,10 +1756,16 @@ mod tests {
         };
         
         client.set_royalty(&admin, &token_id, &new_royalty);
-        
-        // Verify event was emitted
+
+        // Verify RoyaltyRecipientUpdated event emitted with correct old/new addresses
         let events = env.events().all();
-        assert!(events.events().len() > 0);
+        assert_eq!(events.events().len(), 1);
+        let (topics, data): (soroban_sdk::Vec<soroban_sdk::Val>, RoyaltyRecipientUpdatedEvent) =
+            env.events().all().first().unwrap();
+        let _ = topics; // topic is ("royalty",)
+        assert_eq!(data.token_id, token_id);
+        assert_eq!(data.old_recipient, user1);
+        assert_eq!(data.new_recipient, user2);
     }
 
     #[test]


### PR DESCRIPTION
set_royalty already emits RoyaltyRecipientUpdatedEvent with old_recipient and new_recipient when the primary recipient address changes. Strengthen the test to assert both fields explicitly.

Closes #96