### PR TITLE
feat: SafeMath module for overflow-safe royalty calculations

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -36,6 +36,8 @@
 
 #![no_std]
 
+pub mod safe_math;
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype,
     symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Vec,
@@ -2084,20 +2086,11 @@ impl ClipsNftContract {
     /// # Safe price limits
     /// `sale_price` must be ≤ `i128::MAX / 10_000` (≈ 1.7 × 10³⁴ stroops).
     /// Prices above this threshold return `RoyaltyOverflow`.
+    ///
+    /// Delegates to [`safe_math::safe_royalty_amount`] — see that module for
+    /// full overflow-protection documentation.
     pub fn calculate_royalty(sale_price: i128, basis_points: u32) -> Result<i128, Error> {
-        if sale_price <= 0 {
-            return Err(Error::InvalidSalePrice);
-        }
-        // Guard: sale_price * 10_000 must not overflow i128
-        if sale_price > i128::MAX / 10_000 {
-            return Err(Error::RoyaltyOverflow);
-        }
-        let numerator = sale_price
-            .checked_mul(basis_points as i128)
-            .ok_or(Error::RoyaltyOverflow)?
-            .checked_add(5_000)
-            .ok_or(Error::RoyaltyOverflow)?;
-        Ok(numerator / 10_000)
+        safe_math::safe_royalty_amount(sale_price, basis_points)
     }
 }
 

--- a/clips_nft/src/safe_math.rs
+++ b/clips_nft/src/safe_math.rs
@@ -1,0 +1,47 @@
+//! Safe arithmetic helpers for royalty calculations.
+//!
+//! # Overflow protection
+//!
+//! Royalty amounts are computed as:
+//!
+//! ```text
+//! royalty_amount = (sale_price × basis_points + 5_000) / 10_000
+//! ```
+//!
+//! `sale_price` is an `i128`. The multiplication `sale_price × basis_points`
+//! can overflow when `sale_price` is very large. This module guards against
+//! that by:
+//!
+//! 1. Rejecting any `sale_price > i128::MAX / 10_000` before multiplying.
+//! 2. Using `checked_mul` / `checked_add` so any residual overflow returns
+//!    `Err` rather than wrapping silently.
+//!
+//! The maximum safe sale price is `i128::MAX / 10_000 ≈ 1.7 × 10³⁴` stroops,
+//! which is astronomically larger than any realistic Stellar transaction value.
+
+use crate::Error;
+
+/// Compute `(sale_price × basis_points + 5_000) / 10_000` with overflow protection.
+///
+/// # Arguments
+/// * `sale_price`   — Sale price in the asset's smallest unit. Must be > 0.
+/// * `basis_points` — Royalty rate in basis points (1 bp = 0.01 %). Range: 0–10 000.
+///
+/// # Errors
+/// * [`Error::InvalidSalePrice`] — `sale_price` ≤ 0.
+/// * [`Error::RoyaltyOverflow`]  — `sale_price > i128::MAX / 10_000` or intermediate overflow.
+pub fn safe_royalty_amount(sale_price: i128, basis_points: u32) -> Result<i128, Error> {
+    if sale_price <= 0 {
+        return Err(Error::InvalidSalePrice);
+    }
+    // Pre-check: sale_price × 10_000 must fit in i128.
+    if sale_price > i128::MAX / 10_000 {
+        return Err(Error::RoyaltyOverflow);
+    }
+    let numerator = sale_price
+        .checked_mul(basis_points as i128)
+        .ok_or(Error::RoyaltyOverflow)?
+        .checked_add(5_000)
+        .ok_or(Error::RoyaltyOverflow)?;
+    Ok(numerator / 10_000)
+}

--- a/clips_nft/tests/integration.rs
+++ b/clips_nft/tests/integration.rs
@@ -250,3 +250,81 @@ fn test_batch_mint_enforces_gas_safe_limit() {
         .try_batch_mint(&owner, &clip_ids, &metadata_uris, &royalty, &false, &signatures)
         .is_err());
 }
+
+// =============================================================================
+// Issue #115 — Safe math unit tests for royalty calculations
+// =============================================================================
+
+#[test]
+fn test_safe_math_basic_royalty() {
+    // 5 % of 1 000 000 stroops = 50 000 stroops
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(1_000_000, 500).unwrap(),
+        50_000
+    );
+}
+
+#[test]
+fn test_safe_math_zero_bps() {
+    // 0 % royalty → 0
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(1_000_000, 0).unwrap(),
+        0
+    );
+}
+
+#[test]
+fn test_safe_math_full_bps() {
+    // 100 % royalty (10 000 bps)
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(10_000, 10_000).unwrap(),
+        10_000
+    );
+}
+
+#[test]
+fn test_safe_math_max_safe_price() {
+    // Exactly at the safe limit — must succeed
+    let max_safe = i128::MAX / 10_000;
+    assert!(clips_nft::safe_math::safe_royalty_amount(max_safe, 10_000).is_ok());
+    assert!(clips_nft::safe_math::safe_royalty_amount(max_safe, 500).is_ok());
+}
+
+#[test]
+fn test_safe_math_overflow_one_above_limit() {
+    // One above the safe limit — must return RoyaltyOverflow
+    let over = i128::MAX / 10_000 + 1;
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(over, 500),
+        Err(clips_nft::Error::RoyaltyOverflow)
+    );
+}
+
+#[test]
+fn test_safe_math_overflow_i128_max() {
+    // i128::MAX — must return RoyaltyOverflow regardless of bps
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(i128::MAX, 1),
+        Err(clips_nft::Error::RoyaltyOverflow)
+    );
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(i128::MAX, 10_000),
+        Err(clips_nft::Error::RoyaltyOverflow)
+    );
+}
+
+#[test]
+fn test_safe_math_zero_price_fails() {
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(0, 500),
+        Err(clips_nft::Error::InvalidSalePrice)
+    );
+}
+
+#[test]
+fn test_safe_math_negative_price_fails() {
+    assert_eq!(
+        clips_nft::safe_math::safe_royalty_amount(-1, 500),
+        Err(clips_nft::Error::InvalidSalePrice)
+    );
+}


### PR DESCRIPTION
## Summary

Closes #115

Royalty calculations can overflow when sale prices are very large. This PR extracts the safe arithmetic into a dedicated `safe_math` module and adds comprehensive unit tests.

## Changes

- **`clips_nft/src/safe_math.rs`** (new): `safe_royalty_amount(sale_price, basis_points)` helper with:
  - Pre-check: rejects `sale_price > i128::MAX / 10_000` before any multiplication
  - `checked_mul` / `checked_add` for residual overflow protection
  - Full overflow-protection documentation
- **`clips_nft/src/lib.rs`**: `calculate_royalty()` now delegates to `safe_math::safe_royalty_amount()`; module declared as `pub mod safe_math`
- **`clips_nft/tests/integration.rs`**: 8 new unit tests covering basic royalty, zero bps, full bps (10 000), max safe price (`i128::MAX / 10_000`), overflow at limit+1, `i128::MAX` overflow, zero price, and negative price

## Acceptance Criteria

- [x] SafeMath module with checked operations
- [x] Applied to all royalty percentage calculations via `calculate_royalty()`
- [x] Unit tests with maximum i128 values
- [x] Overflow protection documented in module-level doc comment