### PR TITLE
feat: add claim_royalties function for creators

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -214,6 +214,8 @@ pub enum DataKey {
     Frozen(TokenId),
     /// Timestamp of the last metadata refresh per token (persistent).
     MetadataRefreshTime(TokenId),
+    /// Accumulated unclaimed royalty balance per token (persistent).
+    RoyaltyBalance(TokenId),
 }
 
 /// Emergency withdrawal request
@@ -376,6 +378,15 @@ pub struct SignerUpdatedEvent {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RoyaltyUpdatedEvent {
     pub token_id: TokenId,
+}
+
+/// Emitted when accumulated royalties are claimed by the recipient.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoyaltyClaimedEvent {
+    pub token_id: TokenId,
+    pub recipient: Address,
+    pub amount: i128,
 }
 
 /// Emitted when the collection name or symbol is updated.
@@ -1484,6 +1495,8 @@ impl ClipsNftContract {
     /// Pay royalties for a token sale using the SEP-0041 asset in the royalty config.
     ///
     /// Iterates over all recipients and transfers each share via the token client.
+    /// Also accrues the total royalty amount to `RoyaltyBalance(token_id)` so
+    /// recipients can track lifetime earnings and claim via [`claim_royalties`].
     /// For XLM royalties (`asset_address = None`) the marketplace must handle
     /// the transfer directly — this function returns [`Error::InvalidRecipient`].
     ///
@@ -1542,6 +1555,83 @@ impl ClipsNftContract {
                 },
             );
         }
+
+        // Accrue total royalty paid to the token's claimable balance.
+        if cumulative_royalty > 0 {
+            let prev: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RoyaltyBalance(token_id))
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&DataKey::RoyaltyBalance(token_id), &(prev.saturating_add(cumulative_royalty)));
+        }
+
+        Ok(())
+    }
+
+    /// Claim accumulated royalties for a token.
+    ///
+    /// Transfers the full `RoyaltyBalance` for `token_id` to the primary royalty
+    /// recipient using the SEP-0041 asset configured in the royalty. Clears the
+    /// balance atomically (check-effects-interactions) to prevent double-claiming.
+    ///
+    /// Only the primary royalty recipient (index 0) may call this.
+    ///
+    /// Emits: `"roy_claim"` [`RoyaltyClaimedEvent`].
+    ///
+    /// # Arguments
+    /// * `caller`   — Must be the primary royalty recipient.
+    /// * `token_id` — Token whose royalties are being claimed.
+    ///
+    /// # Errors
+    /// * [`Error::InvalidTokenId`]    — token does not exist.
+    /// * [`Error::Unauthorized`]      — caller is not the primary recipient.
+    /// * [`Error::InvalidRecipient`]  — no SEP-0041 asset configured.
+    /// * [`Error::InsufficientBalance`] — no royalties to claim.
+    pub fn claim_royalties(env: Env, caller: Address, token_id: TokenId) -> Result<(), Error> {
+        caller.require_auth();
+
+        let royalty = Self::load_token(&env, token_id)?.royalty;
+        let recipient = royalty
+            .recipients
+            .get(0)
+            .ok_or(Error::InvalidRoyaltySplit)?
+            .recipient;
+
+        if caller != recipient {
+            return Err(Error::Unauthorized);
+        }
+
+        let asset_address = royalty.asset_address.ok_or(Error::InvalidRecipient)?;
+
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RoyaltyBalance(token_id))
+            .unwrap_or(0);
+
+        if balance <= 0 {
+            return Err(Error::InsufficientBalance);
+        }
+
+        // Clear balance before transfer (check-effects-interactions).
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RoyaltyBalance(token_id));
+
+        soroban_sdk::token::TokenClient::new(&env, &asset_address)
+            .transfer(&env.current_contract_address(), &recipient, &balance);
+
+        env.events().publish(
+            (symbol_short!("roy_clm"),),
+            RoyaltyClaimedEvent {
+                token_id,
+                recipient,
+                amount: balance,
+            },
+        );
 
         Ok(())
     }

--- a/clips_nft/tests/integration.rs
+++ b/clips_nft/tests/integration.rs
@@ -250,3 +250,126 @@ fn test_batch_mint_enforces_gas_safe_limit() {
         .try_batch_mint(&owner, &clip_ids, &metadata_uris, &royalty, &false, &signatures)
         .is_err());
 }
+
+// =============================================================================
+// Issue #119 — claim_royalties tests
+// =============================================================================
+
+#[test]
+fn test_claim_royalties_transfers_balance_to_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let sk_bytes = soroban_sdk::BytesN::<32>::random(&env).to_array();
+    let kp = ed25519_dalek::SigningKey::from_bytes(&sk_bytes);
+    let pubkey = BytesN::from_array(&env, &kp.verifying_key().to_bytes());
+    client.set_signer(&admin, &pubkey);
+
+    // Deploy a SEP-0041 token and fund the buyer
+    let token_admin = Address::generate(&env);
+    let asset = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    soroban_sdk::token::StellarAssetClient::new(&env, &asset).mint(&buyer, &1_000_000i128);
+
+    // Mint NFT with SEP-0041 royalty
+    let clip_id = 9001u32;
+    let uri = String::from_str(&env, "ipfs://QmClaim1");
+    let sig = sign_mint(&env, &kp, &creator, clip_id, &uri);
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RoyaltyRecipient { recipient: creator.clone(), basis_points: 500 });
+    let royalty = Royalty { recipients, asset_address: Some(asset.clone()) };
+    let token_id = client.mint(&creator, &clip_id, &uri, &royalty, &false, &sig);
+
+    // Pay royalty (buyer pays 5 % of 1 000 000 = 50 000)
+    client.pay_royalty(&buyer, &token_id, &1_000_000i128);
+
+    // Claim royalties
+    client.claim_royalties(&creator, &token_id);
+
+    // Creator should have received the royalty
+    let creator_balance = soroban_sdk::token::TokenClient::new(&env, &asset).balance(&creator);
+    assert!(creator_balance > 0);
+}
+
+#[test]
+fn test_claim_royalties_prevents_double_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let sk_bytes = soroban_sdk::BytesN::<32>::random(&env).to_array();
+    let kp = ed25519_dalek::SigningKey::from_bytes(&sk_bytes);
+    let pubkey = BytesN::from_array(&env, &kp.verifying_key().to_bytes());
+    client.set_signer(&admin, &pubkey);
+
+    let token_admin = Address::generate(&env);
+    let asset = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    soroban_sdk::token::StellarAssetClient::new(&env, &asset).mint(&buyer, &1_000_000i128);
+
+    let clip_id = 9002u32;
+    let uri = String::from_str(&env, "ipfs://QmClaim2");
+    let sig = sign_mint(&env, &kp, &creator, clip_id, &uri);
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RoyaltyRecipient { recipient: creator.clone(), basis_points: 500 });
+    let royalty = Royalty { recipients, asset_address: Some(asset.clone()) };
+    let token_id = client.mint(&creator, &clip_id, &uri, &royalty, &false, &sig);
+
+    client.pay_royalty(&buyer, &token_id, &1_000_000i128);
+    client.claim_royalties(&creator, &token_id);
+
+    // Second claim should fail — balance is zero
+    let result = client.try_claim_royalties(&creator, &token_id);
+    assert_eq!(result, Err(Ok(clips_nft::Error::InsufficientBalance)));
+}
+
+#[test]
+fn test_claim_royalties_unauthorized_caller_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let sk_bytes = soroban_sdk::BytesN::<32>::random(&env).to_array();
+    let kp = ed25519_dalek::SigningKey::from_bytes(&sk_bytes);
+    let pubkey = BytesN::from_array(&env, &kp.verifying_key().to_bytes());
+    client.set_signer(&admin, &pubkey);
+
+    let token_admin = Address::generate(&env);
+    let asset = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    soroban_sdk::token::StellarAssetClient::new(&env, &asset).mint(&buyer, &1_000_000i128);
+
+    let clip_id = 9003u32;
+    let uri = String::from_str(&env, "ipfs://QmClaim3");
+    let sig = sign_mint(&env, &kp, &creator, clip_id, &uri);
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RoyaltyRecipient { recipient: creator.clone(), basis_points: 500 });
+    let royalty = Royalty { recipients, asset_address: Some(asset.clone()) };
+    let token_id = client.mint(&creator, &clip_id, &uri, &royalty, &false, &sig);
+
+    client.pay_royalty(&buyer, &token_id, &1_000_000i128);
+
+    // Attacker tries to claim — must fail
+    let result = client.try_claim_royalties(&attacker, &token_id);
+    assert_eq!(result, Err(Ok(clips_nft::Error::Unauthorized)));
+}


### PR DESCRIPTION
## Summary

Closes #119

Creators can now claim accumulated royalties directly from the contract.

## Changes

### `clips_nft/src/lib.rs`
- **`DataKey::RoyaltyBalance(TokenId)`** — new persistent key tracking accrued royalties per token
- **`RoyaltyClaimedEvent`** — new event struct with `token_id`, `recipient`, `amount`
- **`pay_royalty()`** — now accrues the total royalty paid to `RoyaltyBalance(token_id)` in addition to transferring to recipients
- **`claim_royalties(caller, token_id)`** — new public function:
  - Verifies `caller` is the primary royalty recipient (index 0)
  - Reads `RoyaltyBalance`, returns `InsufficientBalance` if zero (prevents double-claim)
  - Clears balance **before** transfer (check-effects-interactions pattern)
  - Transfers full balance to recipient via SEP-0041 token client
  - Emits `RoyaltyClaimedEvent`

### `clips_nft/tests/integration.rs`
- `test_claim_royalties_transfers_balance_to_recipient`
- `test_claim_royalties_prevents_double_claim`
- `test_claim_royalties_unauthorized_caller_fails`

## Acceptance Criteria

- [x] `claim_royalties(token_id)` implemented
- [x] Transfers owed amount to royalty recipient
- [x] Emits `RoyaltyClaimedEvent`
- [x] Prevents double claiming via balance-clear before transfer