### PR TITLE
feat: implement contract pause with 24-hour timelock

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -214,6 +214,8 @@ pub enum DataKey {
     Frozen(TokenId),
     /// Timestamp of the last metadata refresh per token (persistent).
     MetadataRefreshTime(TokenId),
+    /// Ledger timestamp at which a scheduled pause becomes active (instance).
+    PauseUnlockTime,
 }
 
 /// Emergency withdrawal request
@@ -378,6 +380,14 @@ pub struct RoyaltyUpdatedEvent {
     pub token_id: TokenId,
 }
 
+/// Emitted when a pause is scheduled (24-hour timelock starts).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseScheduledEvent {
+    /// Ledger timestamp at which the pause becomes active.
+    pub active_at: u64,
+}
+
 /// Emitted when the collection name or symbol is updated.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -503,19 +513,29 @@ impl ClipsNftContract {
     // Pausable  ⚠️ PRIVILEGED — admin only
     // -------------------------------------------------------------------------
 
-    /// Pause the contract. Blocks `mint` and `transfer` until unpaused.
+    /// Schedule a contract pause with a 24-hour timelock.
+    ///
+    /// The pause becomes active 24 hours after this call. Until then, `mint`
+    /// and `transfer` continue to work, giving users advance warning.
+    /// Calling `pause` again while a pause is already scheduled or active
+    /// resets the 24-hour window from the current time.
     ///
     /// ⚠️ **Access Control: Admin only.**
     ///
-    /// Emits: `"paused"` event.
+    /// Emits: `"pause_sched"` [`PauseScheduledEvent`] with the activation timestamp.
     pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
         Self::require_admin(&env, &admin)?;
+        let active_at = env.ledger().timestamp().saturating_add(86_400); // 24 hours
+        env.storage().instance().set(&DataKey::PauseUnlockTime, &active_at);
         env.storage().instance().set(&DataKey::Paused, &true);
-        env.events().publish((symbol_short!("paused"),), ());
+        env.events().publish(
+            (symbol_short!("pse_sched"),),
+            PauseScheduledEvent { active_at },
+        );
         Ok(())
     }
 
-    /// Unpause the contract, re-enabling `mint` and `transfer`.
+    /// Cancel a scheduled or active pause, immediately re-enabling `mint` and `transfer`.
     ///
     /// ⚠️ **Access Control: Admin only.**
     ///
@@ -523,16 +543,19 @@ impl ClipsNftContract {
     pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
         Self::require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().remove(&DataKey::PauseUnlockTime);
         env.events().publish((symbol_short!("unpaused"),), ());
         Ok(())
     }
 
-    /// Returns `true` if the contract is currently paused.
+    /// Returns `true` if the contract is currently paused (timelock has elapsed).
     pub fn is_paused(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
+        Self::check_paused(&env)
+    }
+
+    /// Returns the timestamp at which a scheduled pause becomes active, or `None`.
+    pub fn pause_active_at(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::PauseUnlockTime)
     }
 
     /// Request an emergency withdrawal of XLM (or any other token).
@@ -2026,17 +2049,30 @@ impl ClipsNftContract {
         Ok(())
     }
 
-    /// Return `ContractPaused` if the pause flag is set.
+    /// Return `ContractPaused` if the pause flag is set and the 24-hour timelock has elapsed.
     fn require_not_paused(env: &Env) -> Result<(), Error> {
-        if env
-            .storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
-        {
+        if Self::check_paused(env) {
             return Err(Error::ContractPaused);
         }
         Ok(())
+    }
+
+    /// Returns `true` if the pause flag is set AND the 24-hour timelock has elapsed.
+    fn check_paused(env: &Env) -> bool {
+        let flagged: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if !flagged {
+            return false;
+        }
+        // Check if the timelock has elapsed.
+        match env.storage().instance().get::<DataKey, u64>(&DataKey::PauseUnlockTime) {
+            Some(active_at) => env.ledger().timestamp() >= active_at,
+            // No timelock stored — legacy pause (immediately active).
+            None => true,
+        }
     }
 
     /// Validate royalty recipients and append the platform 1 % cut if absent.

--- a/clips_nft/tests/integration.rs
+++ b/clips_nft/tests/integration.rs
@@ -250,3 +250,146 @@ fn test_batch_mint_enforces_gas_safe_limit() {
         .try_batch_mint(&owner, &clip_ids, &metadata_uris, &royalty, &false, &signatures)
         .is_err());
 }
+
+// =============================================================================
+// Issue #120 — Pause with 24-hour timelock tests
+// =============================================================================
+
+#[test]
+fn test_pause_timelock_mint_still_works_before_24h() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let sk_bytes = soroban_sdk::BytesN::<32>::random(&env).to_array();
+    let kp = ed25519_dalek::SigningKey::from_bytes(&sk_bytes);
+    let pubkey = BytesN::from_array(&env, &kp.verifying_key().to_bytes());
+    client.set_signer(&admin, &pubkey);
+
+    // Schedule pause
+    client.pause(&admin);
+
+    // Advance time by 23 hours — still within the 24-hour window
+    env.ledger().with_mut(|l| l.timestamp += 23 * 3600);
+
+    // Mint should still succeed (timelock not elapsed)
+    let clip_id = 8001u32;
+    let uri = String::from_str(&env, "ipfs://QmTimelock1");
+    let sig = sign_mint(&env, &kp, &user, clip_id, &uri);
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RoyaltyRecipient { recipient: user.clone(), basis_points: 500 });
+    let royalty = Royalty { recipients, asset_address: None };
+    let result = client.try_mint(&user, &clip_id, &uri, &royalty, &false, &sig);
+    assert!(result.is_ok(), "mint should succeed before 24h timelock elapses");
+}
+
+#[test]
+fn test_pause_timelock_blocks_mint_after_24h() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let sk_bytes = soroban_sdk::BytesN::<32>::random(&env).to_array();
+    let kp = ed25519_dalek::SigningKey::from_bytes(&sk_bytes);
+    let pubkey = BytesN::from_array(&env, &kp.verifying_key().to_bytes());
+    client.set_signer(&admin, &pubkey);
+
+    // Schedule pause
+    client.pause(&admin);
+
+    // Advance time by exactly 24 hours — timelock elapsed
+    env.ledger().with_mut(|l| l.timestamp += 86_400);
+
+    let clip_id = 8002u32;
+    let uri = String::from_str(&env, "ipfs://QmTimelock2");
+    let sig = sign_mint(&env, &kp, &user, clip_id, &uri);
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RoyaltyRecipient { recipient: user.clone(), basis_points: 500 });
+    let royalty = Royalty { recipients, asset_address: None };
+    let result = client.try_mint(&user, &clip_id, &uri, &royalty, &false, &sig);
+    assert_eq!(result, Err(Ok(clips_nft::Error::ContractPaused)));
+}
+
+#[test]
+fn test_pause_timelock_stores_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let now = env.ledger().timestamp();
+    client.pause(&admin);
+
+    let active_at = client.pause_active_at().expect("pause_active_at should be set");
+    assert_eq!(active_at, now + 86_400, "pause should activate 24h from now");
+}
+
+#[test]
+fn test_unpause_cancels_timelock_immediately() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let sk_bytes = soroban_sdk::BytesN::<32>::random(&env).to_array();
+    let kp = ed25519_dalek::SigningKey::from_bytes(&sk_bytes);
+    let pubkey = BytesN::from_array(&env, &kp.verifying_key().to_bytes());
+    client.set_signer(&admin, &pubkey);
+
+    // Schedule pause then immediately cancel
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    // Advance past the original 24h window
+    env.ledger().with_mut(|l| l.timestamp += 86_400 + 1);
+
+    // Mint should succeed — unpause cleared the timelock
+    let clip_id = 8003u32;
+    let uri = String::from_str(&env, "ipfs://QmTimelock3");
+    let sig = sign_mint(&env, &kp, &user, clip_id, &uri);
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RoyaltyRecipient { recipient: user.clone(), basis_points: 500 });
+    let royalty = Royalty { recipients, asset_address: None };
+    let result = client.try_mint(&user, &clip_id, &uri, &royalty, &false, &sig);
+    assert!(result.is_ok(), "mint should succeed after unpause");
+}
+
+#[test]
+fn test_is_paused_false_before_timelock_elapses() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(ClipsNftContract, ());
+    let client = ClipsNftContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    client.pause(&admin);
+
+    // Before 24h — is_paused should return false
+    assert!(!client.is_paused());
+
+    // After 24h — is_paused should return true
+    env.ledger().with_mut(|l| l.timestamp += 86_400);
+    assert!(client.is_paused());
+}


### PR DESCRIPTION
## Summary

Closes #120

Improves the emergency pause mechanism with a 24-hour timelock so users have advance warning before minting and transfers are disabled.

## Changes

### `clips_nft/src/lib.rs`
- **`DataKey::PauseUnlockTime`** — new instance key storing the timestamp at which a scheduled pause becomes active
- **`PauseScheduledEvent { active_at }`** — new event emitted when a pause is scheduled
- **`pause()`** — now stores `PauseUnlockTime = now + 86_400s` (24 hours) and emits `PauseScheduledEvent`; the pause flag is set immediately but enforcement is delayed
- **`unpause()`** — immediately clears both the `Paused` flag and `PauseUnlockTime`, cancelling any pending pause
- **`is_paused()`** — returns `true` only when the flag is set **and** the 24-hour timelock has elapsed
- **`pause_active_at()`** — new view returning `Option<u64>` with the scheduled activation timestamp
- **`check_paused()`** — internal helper used by `require_not_paused()` and `is_paused()`

### `clips_nft/tests/integration.rs`
- `test_pause_timelock_mint_still_works_before_24h`
- `test_pause_timelock_blocks_mint_after_24h`
- `test_pause_timelock_stores_timestamp`
- `test_unpause_cancels_timelock_immediately`
- `test_is_paused_false_before_timelock_elapses`

## Acceptance Criteria

- [x] `pause()` and `unpause()` with 24-hour delay on pause activation
- [x] Pause timestamp stored in `DataKey::PauseUnlockTime`
- [x] `mint` and `transfer` blocked when paused (after timelock elapses)
- [x] Users have 24-hour warning window before pause takes effect