### PR TITLE
feat: implement issues #164, #165, #166, #167 — NFT tracking, ownership verification, wallet disconnect, subscription listener

### DIFF
--- a/scripts/clip-store.js
+++ b/scripts/clip-store.js
@@ -1,0 +1,84 @@
+/**
+ * clip-store.js — In-memory Clip store with NFT tracking fields.
+ *
+ * Issue #166: Track which clips have been minted and their on-chain mint
+ * address. Adds mintAddress, mintedAt, and nftStatus to each Clip record
+ * and prevents double-minting the same clip.
+ *
+ * nftStatus values: "none" | "minting" | "minted" | "failed"
+ */
+
+/** @type {Map<number, Clip>} */
+const clips = new Map();
+
+/**
+ * @typedef {Object} Clip
+ * @property {number}      id
+ * @property {string}      title
+ * @property {string|null} mintAddress  - On-chain token/contract address after mint.
+ * @property {Date|null}   mintedAt     - Timestamp of successful mint.
+ * @property {string}      nftStatus   - "none" | "minting" | "minted" | "failed"
+ */
+
+/**
+ * Create a new clip record.
+ * @param {number} id
+ * @param {string} title
+ * @returns {Clip}
+ */
+function createClip(id, title) {
+  if (clips.has(id)) throw new Error(`Clip ${id} already exists`);
+  const clip = { id, title, mintAddress: null, mintedAt: null, nftStatus: "none" };
+  clips.set(id, clip);
+  return clip;
+}
+
+/**
+ * Retrieve a clip by ID.
+ * @param {number} id
+ * @returns {Clip}
+ */
+function getClip(id) {
+  const clip = clips.get(id);
+  if (!clip) throw new Error(`Clip ${id} not found`);
+  return clip;
+}
+
+/**
+ * Mark a clip as currently being minted.
+ * Throws if the clip is already minted or in-progress (double-mint prevention).
+ * @param {number} id
+ */
+function beginMint(id) {
+  const clip = getClip(id);
+  if (clip.nftStatus === "minted") {
+    throw new Error(`Clip ${id} has already been minted (mintAddress: ${clip.mintAddress})`);
+  }
+  if (clip.nftStatus === "minting") {
+    throw new Error(`Clip ${id} mint is already in progress`);
+  }
+  clip.nftStatus = "minting";
+}
+
+/**
+ * Record a successful mint result.
+ * @param {number} id
+ * @param {string} mintAddress - On-chain token address / token ID string.
+ */
+function completeMint(id, mintAddress) {
+  const clip = getClip(id);
+  clip.mintAddress = mintAddress;
+  clip.mintedAt = new Date();
+  clip.nftStatus = "minted";
+}
+
+/**
+ * Mark a mint as failed, allowing a retry.
+ * @param {number} id
+ */
+function failMint(id) {
+  const clip = getClip(id);
+  clip.nftStatus = "failed";
+}
+
+export { createClip, getClip, beginMint, completeMint, failMint };

--- a/scripts/nft-ownership.js
+++ b/scripts/nft-ownership.js
@@ -1,0 +1,56 @@
+/**
+ * nft-ownership.js — On-chain NFT ownership verification.
+ *
+ * Issue #164: Before allowing certain actions (e.g. editing a minted clip),
+ * verify the caller still owns the NFT on-chain by querying the Soroban
+ * contract's owner_of() function.
+ *
+ * Environment variables:
+ *   CONTRACT_ID        - Deployed ClipCashNFT contract address (required)
+ *   RPC_URL            - Soroban RPC endpoint (default: https://soroban-testnet.stellar.org)
+ *   NETWORK_PASSPHRASE - Network passphrase (default: Test SDF Network ; September 2015)
+ */
+
+import { Client } from "@clipcash/clips-nft";
+
+const CONTRACT_ID = process.env.CONTRACT_ID;
+const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
+const NETWORK_PASSPHRASE =
+  process.env.NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
+
+/**
+ * Verify that `walletAddress` is the current on-chain owner of the token
+ * identified by `tokenId` (the numeric token ID returned at mint time).
+ *
+ * @param {number} tokenId       - On-chain token ID (u32).
+ * @param {string} walletAddress - Stellar G-address to check ownership for.
+ * @returns {Promise<{ owned: boolean, error: string|null }>}
+ */
+async function verifyNFTOwnership(tokenId, walletAddress) {
+  if (!CONTRACT_ID) {
+    return { owned: false, error: "CONTRACT_ID environment variable is not set" };
+  }
+
+  const client = new Client({
+    contractId: CONTRACT_ID,
+    networkPassphrase: NETWORK_PASSPHRASE,
+    rpcUrl: RPC_URL,
+  });
+
+  try {
+    const tx = await client.owner_of({ token_id: tokenId });
+    const result = await tx.simulate();
+
+    if (result.result.isErr()) {
+      const errMsg = result.result.unwrapErr().message ?? "InvalidTokenId";
+      return { owned: false, error: errMsg };
+    }
+
+    const owner = result.result.unwrap();
+    return { owned: owner === walletAddress, error: null };
+  } catch (err) {
+    return { owned: false, error: err.message ?? String(err) };
+  }
+}
+
+export { verifyNFTOwnership };

--- a/scripts/subscription-listener.js
+++ b/scripts/subscription-listener.js
@@ -1,0 +1,159 @@
+/**
+ * subscription-listener.js — Stellar asset payment verification listener.
+ *
+ * Issue #167: Listen for incoming Stellar payments for subscriptions and
+ * auto-activate the plan.
+ *
+ * Behaviour:
+ *   - Polls Horizon for new payments to the platform's receiving address.
+ *   - Matches each payment by memo (subscription ID) and expected amount.
+ *   - Updates the matching Subscription record to status "active".
+ *   - Creates a Payout record for platform revenue (stub for future use).
+ *   - Tracks the last-seen cursor so restarts don't reprocess old payments.
+ *
+ * Environment variables:
+ *   HORIZON_URL          - Horizon base URL (default: https://horizon-testnet.stellar.org)
+ *   PLATFORM_ADDRESS     - Stellar G-address that receives subscription payments (required)
+ *   POLL_INTERVAL_MS     - Polling interval in ms (default: 10000)
+ */
+
+const HORIZON_URL = process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
+const PLATFORM_ADDRESS = process.env.PLATFORM_ADDRESS;
+const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS || "10000");
+
+/** @type {Map<string, Subscription>} */
+const subscriptions = new Map();
+
+/** @type {Payout[]} */
+const payouts = [];
+
+/**
+ * @typedef {Object} Subscription
+ * @property {string} id
+ * @property {string} userId
+ * @property {string} status       - "pending" | "active" | "cancelled"
+ * @property {string} expectedAmount - Amount in XLM (e.g. "10.0000000")
+ */
+
+/**
+ * @typedef {Object} Payout
+ * @property {string} subscriptionId
+ * @property {string} amount
+ * @property {Date}   createdAt
+ */
+
+/** Cursor for Horizon pagination — tracks last processed payment. */
+let cursor = "now";
+
+/**
+ * Register a pending subscription (called when user initiates checkout).
+ * @param {string} id
+ * @param {string} userId
+ * @param {string} expectedAmount - e.g. "10.0000000"
+ * @returns {Subscription}
+ */
+function registerSubscription(id, userId, expectedAmount) {
+  const sub = { id, userId, status: "pending", expectedAmount };
+  subscriptions.set(id, sub);
+  return sub;
+}
+
+/**
+ * Fetch one page of payments from Horizon for the platform address.
+ * @returns {Promise<Array>}
+ */
+async function fetchPayments() {
+  const url =
+    `${HORIZON_URL}/accounts/${PLATFORM_ADDRESS}/payments` +
+    `?order=asc&limit=50&cursor=${cursor}&include_failed=false`;
+
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Horizon error ${res.status}: ${await res.text()}`);
+
+  const body = await res.json();
+  return body._embedded?.records ?? [];
+}
+
+/**
+ * Process a single Horizon payment record.
+ * @param {Object} payment
+ */
+function processPayment(payment) {
+  // Only handle native XLM payments (type "payment", asset_type "native")
+  if (payment.type !== "payment" || payment.asset_type !== "native") return;
+  if (payment.to !== PLATFORM_ADDRESS) return;
+
+  const memo = payment.transaction?.memo ?? payment.memo;
+  const amount = payment.amount;
+
+  const sub = subscriptions.get(memo);
+  if (!sub) return; // No matching subscription
+
+  if (sub.status !== "pending") return; // Already processed
+
+  if (sub.expectedAmount && sub.expectedAmount !== amount) {
+    console.warn(
+      `[subscription-listener] Amount mismatch for sub ${memo}: ` +
+      `expected ${sub.expectedAmount}, got ${amount}`
+    );
+    return;
+  }
+
+  sub.status = "active";
+  console.log(`[subscription-listener] Activated subscription ${memo} for user ${sub.userId}`);
+
+  // Stub: create a payout record for platform revenue tracking
+  payouts.push({ subscriptionId: memo, amount, createdAt: new Date() });
+}
+
+/**
+ * Run one polling cycle: fetch new payments and process each one.
+ */
+async function poll() {
+  try {
+    const records = await fetchPayments();
+    for (const payment of records) {
+      processPayment(payment);
+      cursor = payment.paging_token;
+    }
+  } catch (err) {
+    console.error("[subscription-listener] Poll error:", err.message);
+  }
+}
+
+/** @type {ReturnType<typeof setInterval>|null} */
+let timer = null;
+
+/**
+ * Start the subscription payment listener.
+ * @param {string} [startCursor="now"] - Horizon paging cursor to start from.
+ */
+function startListener(startCursor = "now") {
+  if (!PLATFORM_ADDRESS) {
+    throw new Error("PLATFORM_ADDRESS environment variable is required");
+  }
+  cursor = startCursor;
+  console.log(`[subscription-listener] Starting — polling every ${POLL_INTERVAL_MS}ms`);
+  timer = setInterval(poll, POLL_INTERVAL_MS);
+  // Run immediately on start
+  poll();
+}
+
+/** Stop the listener. */
+function stopListener() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+export {
+  startListener,
+  stopListener,
+  registerSubscription,
+  subscriptions,
+  payouts,
+  // exported for testing
+  processPayment,
+  poll,
+};

--- a/scripts/wallet-service.js
+++ b/scripts/wallet-service.js
@@ -1,0 +1,86 @@
+/**
+ * wallet-service.js — Wallet management service.
+ *
+ * Issue #165: Users should be able to disconnect a previously connected
+ * Stellar wallet.
+ *
+ * DELETE /wallets/:id
+ *   - Ownership check: only the authenticated user who owns the wallet may
+ *     disconnect it.
+ *   - Guard: refuses disconnect if the wallet has active (minted) NFTs or
+ *     pending payouts.
+ *   - Soft-delete: sets deletedAt timestamp rather than removing the record.
+ *   - Returns a JSON success message on success.
+ *
+ * This module exports a plain handler function so it can be mounted on any
+ * Express-compatible router.
+ */
+
+/** @type {Map<string, Wallet>} */
+const wallets = new Map();
+
+/**
+ * @typedef {Object} Wallet
+ * @property {string}    id
+ * @property {string}    userId        - Owner's user ID.
+ * @property {string}    address       - Stellar G-address.
+ * @property {boolean}   hasActiveNFTs - True if wallet holds minted NFTs.
+ * @property {boolean}   hasPendingPayouts - True if payouts are pending.
+ * @property {Date|null} deletedAt     - Set on soft-delete.
+ */
+
+/**
+ * Register a wallet (used in tests / seeding).
+ * @param {string} id
+ * @param {string} userId
+ * @param {string} address
+ * @returns {Wallet}
+ */
+function registerWallet(id, userId, address) {
+  const wallet = {
+    id,
+    userId,
+    address,
+    hasActiveNFTs: false,
+    hasPendingPayouts: false,
+    deletedAt: null,
+  };
+  wallets.set(id, wallet);
+  return wallet;
+}
+
+/**
+ * Express-style handler for DELETE /wallets/:id.
+ *
+ * Expects `req.user.id` to be set by upstream auth middleware.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ */
+function disconnectWallet(req, res) {
+  const { id } = req.params;
+  const requestingUserId = req.user?.id;
+
+  const wallet = wallets.get(id);
+
+  if (!wallet || wallet.deletedAt) {
+    return res.status(404).json({ error: "Wallet not found" });
+  }
+
+  if (wallet.userId !== requestingUserId) {
+    return res.status(403).json({ error: "Not authorized to disconnect this wallet" });
+  }
+
+  if (wallet.hasActiveNFTs) {
+    return res.status(409).json({ error: "Cannot disconnect wallet with active NFTs" });
+  }
+
+  if (wallet.hasPendingPayouts) {
+    return res.status(409).json({ error: "Cannot disconnect wallet with pending payouts" });
+  }
+
+  wallet.deletedAt = new Date();
+  return res.status(200).json({ message: "Wallet disconnected successfully" });
+}
+
+export { registerWallet, disconnectWallet, wallets };


### PR DESCRIPTION
## Summary

This PR implements four backend service-layer features requested in the Stellar Wave issue tracker.

---

### Issue #166 — [NFT] Add minted NFT tracking

**File:** `scripts/clip-store.js`

Adds `mintAddress`, `mintedAt`, and `nftStatus` fields to the Clip record.

- `nftStatus` values: `"none"` | `"minting"` | `"minted"` | `"failed"`
- `beginMint(id)` — transitions status to `"minting"`; throws if already `"minted"` or `"minting"` (double-mint prevention)
- `completeMint(id, mintAddress)` — records the on-chain address and sets `mintedAt`
- `failMint(id)` — resets to `"failed"` so the clip can be retried

Closes #166

---

### Issue #164 — [Web3] Implement on-chain NFT ownership verification

**File:** `scripts/nft-ownership.js`

Adds `verifyNFTOwnership(tokenId, walletAddress)` which queries the deployed Soroban contract's `owner_of()` function via the generated TypeScript client.

- Returns `{ owned: boolean, error: string|null }`
- Reads `CONTRACT_ID`, `RPC_URL`, and `NETWORK_PASSPHRASE` from environment
- Used before allowing actions such as editing a minted clip

Closes #164

---

### Issue #165 — [Web3] Implement wallet disconnect endpoint

**File:** `scripts/wallet-service.js`

Adds `disconnectWallet(req, res)` — an Express-compatible handler for `DELETE /wallets/:id`.

- Ownership check: only the authenticated user who owns the wallet may disconnect it
- Guard: returns `409` if the wallet has active NFTs or pending payouts
- Soft-delete: sets `deletedAt` timestamp instead of removing the record
- Returns `200 { message: "Wallet disconnected successfully" }` on success

Closes #165

---

### Issue #167 — [Subscription] Add Stellar asset payment verification listener

**File:** `scripts/subscription-listener.js`

Adds a polling-based Horizon listener that auto-activates subscriptions on payment receipt.

- Polls `GET /accounts/{PLATFORM_ADDRESS}/payments` on Horizon (configurable interval, default 10 s)
- Matches each native XLM payment by memo (subscription ID) and expected amount
- Updates the matching `Subscription` record status to `"active"`
- Creates a stub `Payout` record for future platform revenue tracking
- Tracks the Horizon paging cursor so restarts don't reprocess old payments
- `startListener(cursor?)` / `stopListener()` for lifecycle control

Closes #167

---

## Testing

All four files pass Node.js ESM syntax check (`node --input-type=module --check`). The Rust contract layer is unchanged.