### PR TITLE
 feat: mint_with_signature nonce replay protection, rate limiting alias, revoke approvals

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -175,6 +175,10 @@ pub enum DataKey {
     TokenIndex(u32),
     /// Task 3: per-owner enumeration index
     OwnerTokenIndex(Address, u32),
+    /// Task 1: per-wallet nonce for mint_with_signature replay protection
+    LastMintNonce(Address),
+    /// Task 1: used signature hashes for replay protection
+    UsedSignature(BytesN<32>),
 }
 
 // =============================================================================
@@ -803,6 +807,35 @@ impl ClipsNftContract {
 
     pub fn get_mint_cooldown(env: Env) -> u64 {
         env.storage().instance().get(&DataKey::MintCooldownSeconds).unwrap_or(DEFAULT_MINT_COOLDOWN_SECONDS)
+    }
+
+    // Task 2: alias for set_mint_cooldown
+    pub fn set_mint_cooldown_seconds(env: Env, admin: Address, seconds: u64) -> Result<(), Error> {
+        Self::set_mint_cooldown(env, admin, seconds)
+    }
+
+    // Task 4: revoke a single-token approval
+    pub fn revoke_approval(env: Env, caller: Address, token_id: TokenId) -> Result<(), Error> {
+        caller.require_auth();
+        let data: TokenData = Self::load_token(&env, token_id)?;
+        if data.owner != caller {
+            return Err(Error::Unauthorized);
+        }
+        env.storage().persistent().remove(&DataKey::Approved(token_id));
+        Ok(())
+    }
+
+    // Task 4: revoke all operator approvals for the caller
+    pub fn revoke_all_approvals(env: Env, caller: Address, operator: Address) -> Result<(), Error> {
+        caller.require_auth();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ApprovalForAll(caller.clone(), operator.clone()));
+        env.events().publish(
+            (symbol_short!("app_all"), caller.clone(), operator.clone()),
+            ApprovalForAllEvent { owner: caller, operator, approved: false },
+        );
+        Ok(())
     }
 
     pub fn blacklist_clip(env: Env, admin: Address, clip_id: u32) -> Result<(), Error> {


### PR DESCRIPTION
closes #288 
closes #289 
closes #290 
closes #291

PR Description:
  
  Summary
  
  Implements four open-source issues for the clips_nft Soroban NFT contract.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 1 — mint_with_signature with nonce-based replay protection
  
  Added two missing DataKey variants required by the existing mint_with_signature implementation:
  
  - LastMintNonce(Address) — tracks the last used nonce per wallet to enforce strictly-increasing nonces
  - UsedSignature(BytesN<32>) — records consumed signature hashes to prevent replay attacks
  
  The mint_with_signature function was already partially implemented but would panic at runtime due to these missing storage keys. With these variants
  added, the full replay-protection flow works: nonce check → signature verify → mark hash used → record nonce.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 2 — Per-wallet rate limiting (set_mint_cooldown_seconds alias)
  
  The LastMintTimestamp(Address) tracking and enforce_mint_cooldown logic were already wired into mint. Added the required set_mint_cooldown_seconds
   alias:
  
  pub fn set_mint_cooldown_seconds(env, admin, seconds) -> Result<(), Error>
  
  This satisfies the acceptance criteria for a configurable cooldown period with a named alias.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 3 — Comprehensive custom errors
  
  All required error variants were already defined and used throughout the contract:
  
  - ClipAlreadyMinted, Unauthorized, InsufficientBalance, InvalidSignature, MintCooldownActive, ContractPaused, etc.
  
  No changes needed — the error coverage was already complete.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Task 4 — Revoke approvals
  
  Added two new public functions:
  
  pub fn revoke_approval(env, caller, token_id) -> Result<(), Error>
  
  Removes the single-token approval for token_id. Only the token owner may call this.
  
  pub fn revoke_all_approvals(env, caller, operator) -> Result<(), Error>
  
  Removes the ApprovalForAll entry for (caller, operator) and emits an ApprovalForAllEvent with approved: false.
