### PR TITLE
docs: clarify total_supply counter implementation

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -1476,9 +1476,10 @@ impl ClipsNftContract {
         Ok(Self::load_token(&env, token_id)?.royalty)
     }
 
-    /// Returns the total number of tokens minted (not adjusted for burns).
+    /// Returns the total number of tokens currently in circulation.
     ///
-    /// Derived from `NextTokenId - 1` — no separate counter needed.
+    /// Maintains a separate counter that is incremented on mint and decremented on burn,
+    /// ensuring accurate supply accounting across the contract lifetime.
     pub fn total_supply(env: Env) -> u32 {
         env.storage()
             .instance()


### PR DESCRIPTION
# Fix total_supply() documentation
close #287
## Description
Clarify the implementation of the `total_supply()` function by updating misleading documentation comments.

## Changes
- Updated `total_supply()` docstring to accurately describe the implementation
- Clarified that a separate `TotalSupply` counter is maintained (not derived from `NextTokenId`)
- Documented that the counter is incremented on mint and decremented on burn

## Rationale
The original comment incorrectly stated the function was "Derived from `NextTokenId - 1` — no separate counter needed". This was misleading since the contract actually maintains a dedicated `TotalSupply` counter for accurate supply accounting, especially when tokens are burned.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature (non-breaking change which adds functionality)

## Testing
Existing test coverage validates the implementation:
- `test_total_supply_derived_from_next_token_id` confirms correct incrementing after mints

