### PR TITLE
Add max supply, fee payer support, and recovery entrypoint for clips_nft

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -55,6 +55,9 @@ pub enum Error {
     MintingPaused = 25,
     CircuitBreakerTripped = 26,
     MetadataLocked = 27,
+    MaxSupplyReached = 28,
+    InvalidMaxSupply = 29,
+    InvalidRecoverAmount = 30,
 }
 
 // =============================================================================
@@ -150,6 +153,7 @@ pub enum DataKey {
     MintCooldownSeconds,
     ReentrancyLock,
     TotalSupply,
+    MaxSupply,
     ContractVersion,
     CircuitBreakerEnabled,
     CircuitBreakerThreshold,
@@ -404,6 +408,7 @@ impl ClipsNftContract {
         env.storage().instance().set(&DataKey::CircuitBreakerWindowSeconds, &DEFAULT_CIRCUIT_BREAKER_WINDOW_SECONDS);
         env.storage().instance().set(&DataKey::CircuitBreakerWindowStart, &0u64);
         env.storage().instance().set(&DataKey::CircuitBreakerWindowCount, &0u64);
+        env.storage().instance().set(&DataKey::MaxSupply, &Option::<u32>::None);
         env.storage().instance().set(&DataKey::BackendAddress, &admin);
     }
 
@@ -545,6 +550,31 @@ impl ClipsNftContract {
         env.storage().instance().get(&DataKey::PendingOwner)
     }
 
+    /// Set or clear the global maximum supply cap for mintable NFTs.
+    ///
+    /// Passing `None` removes the cap.
+    pub fn set_max_supply(env: Env, admin: Address, max_supply: Option<u32>) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        if let Some(max_supply) = max_supply {
+            let supply: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+            if max_supply < supply {
+                return Err(Error::InvalidMaxSupply);
+            }
+        }
+        env.storage().instance().set(&DataKey::MaxSupply, &max_supply);
+        Ok(())
+    }
+
+    pub fn max_supply(env: Env) -> Option<u32> {
+        env.storage().instance().get(&DataKey::MaxSupply).unwrap_or(None)
+    }
+
+    pub fn remaining_supply(env: Env) -> Option<u32> {
+        let max_supply: Option<u32> = env.storage().instance().get(&DataKey::MaxSupply).unwrap_or(None);
+        let supply: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        max_supply.map(|cap| cap.saturating_sub(supply))
+    }
+
     // -------------------------------------------------------------------------
     // Task 1: Safe math — mint with overflow-safe royalty validation
     // -------------------------------------------------------------------------
@@ -558,9 +588,13 @@ impl ClipsNftContract {
         animation_url: Option<String>,
         royalty: Royalty,
         is_soulbound: bool,
+        fee_payer: Option<Address>,
         signature: BytesN<64>,
     ) -> Result<TokenId, Error> {
         to.require_auth();
+        if let Some(fee_payer) = fee_payer.clone() {
+            fee_payer.require_auth();
+        }
         Self::require_not_paused(&env)?;
         if env
             .storage()
@@ -575,6 +609,12 @@ impl ClipsNftContract {
         }
         Self::enforce_mint_cooldown(&env, &to)?;
         Self::check_circuit_breaker(&env, 1)?;
+        let current_supply: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        if let Some(max_supply) = env.storage().instance().get::<DataKey, Option<u32>>(&DataKey::MaxSupply).unwrap_or(None) {
+            if current_supply >= max_supply {
+                return Err(Error::MaxSupplyReached);
+            }
+        }
         Self::validate_url(&env, &image)?;
         Self::validate_url(&env, &animation_url)?;
         Self::verify_clip_signature(&env, &to, clip_id, &metadata_uri, &signature)?;
@@ -1327,6 +1367,15 @@ impl ClipsNftContract {
         env.storage().instance().set(&DataKey::LastWithdrawalTime, &env.ledger().timestamp());
         soroban_sdk::token::TokenClient::new(&env, &asset).transfer(&env.current_contract_address(), &admin, &amount);
         env.events().publish((symbol_short!("wdraw_exe"), admin.clone()), WithdrawExecutedEvent { amount, recipient: admin });
+        Ok(())
+    }
+
+    pub fn recover_token(env: Env, admin: Address, asset: Address, amount: i128) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        if amount <= 0 {
+            return Err(Error::InvalidRecoverAmount);
+        }
+        soroban_sdk::token::TokenClient::new(&env, &asset).transfer(&env.current_contract_address(), &admin, &amount);
         Ok(())
     }
 
@@ -2532,6 +2581,15 @@ impl ClipsNftContract {
         env.storage().instance().set(&DataKey::LastWithdrawalTime, &env.ledger().timestamp());
         soroban_sdk::token::TokenClient::new(&env, &asset).transfer(&env.current_contract_address(), &admin, &amount);
         env.events().publish((symbol_short!("wdraw_exe"), admin.clone()), WithdrawExecutedEvent { amount, recipient: admin });
+        Ok(())
+    }
+
+    pub fn recover_token(env: Env, admin: Address, asset: Address, amount: i128) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        if amount <= 0 {
+            return Err(Error::InvalidRecoverAmount);
+        }
+        soroban_sdk::token::TokenClient::new(&env, &asset).transfer(&env.current_contract_address(), &admin, &amount);
         Ok(())
     }
 

--- a/clips_nft/tests/integration.rs
+++ b/clips_nft/tests/integration.rs
@@ -89,6 +89,7 @@ fn test_integration_wallet_simulation_mint_and_royalty() {
         &None, // animation_url
         &royalty,
         &false,
+        &None,
         &signature,
     );
 
@@ -382,7 +383,7 @@ fn test_pause_timelock_mint_still_works_before_24h() {
         recipients,
         asset_address: None,
     };
-    let result = client.try_mint(&user, &clip_id, &uri, &None, &None, &royalty, &false, &sig);
+    let result = client.try_mint(&user, &clip_id, &uri, &None, &None, &royalty, &false, &None, &sig);
     assert!(
         result.is_ok(),
         "mint should succeed before 24h timelock elapses"
@@ -421,7 +422,7 @@ fn test_pause_timelock_blocks_mint_after_24h() {
         recipients,
         asset_address: None,
     };
-    let result = client.try_mint(&user, &clip_id, &uri, &None, &None, &royalty, &false, &sig);
+    let result = client.try_mint(&user, &clip_id, &uri, &None, &None, &royalty, &false, &None, &sig);
     assert!(
         result.is_err(),
         "mint should fail after 24h timelock elapses"
@@ -466,7 +467,7 @@ fn test_pay_royalty_sep41_transfers_to_recipient() {
         asset_address: Some(asset.clone()),
     };
     let token_id = client.mint(
-        &creator, &clip_id, &uri, &None, &None, &royalty, &false, &sig,
+        &creator, &clip_id, &uri, &None, &None, &royalty, &false, &None, &sig,
     );
 
     let sale_price = 1_000_000i128;
@@ -513,7 +514,7 @@ fn test_claim_royalties_unauthorized_caller_fails() {
         recipients,
         asset_address: None,
     };
-    let result = client.try_mint(&user, &clip_id, &uri, &None, &None, &royalty, &false, &sig);
+    let result = client.try_mint(&user, &clip_id, &uri, &None, &None, &royalty, &false, &None, &sig);
     assert!(result.is_ok(), "mint should succeed after unpause");
 }
 

--- a/clips_nft/tests/sep41_royalty_integration.rs
+++ b/clips_nft/tests/sep41_royalty_integration.rs
@@ -66,7 +66,7 @@ fn test_sep41_pay_royalty_multi_recipient_split() {
     };
     let token_id = ctx
         .client
-        .mint(&creator, &502, &uri, &None, &None, &royalty, &false, &sig);
+        .mint(&creator, &502, &uri, &None, &None, &royalty, &false, &None, &sig);
 
     let sale_price = 1_000_000i128;
     ctx.client.pay_royalty(&buyer, &token_id, &sale_price);

--- a/clips_nft/tests/test_helpers.rs
+++ b/clips_nft/tests/test_helpers.rs
@@ -108,6 +108,7 @@ pub fn mint_clip(ctx: &TestContext, owner: &Address, clip_id: u32, is_soulbound:
         &None,
         &royalty,
         &is_soulbound,
+        &None,
         &sig,
     )
 }

--- a/clips_nft/tests/test_metadata_fields.rs
+++ b/clips_nft/tests/test_metadata_fields.rs
@@ -63,6 +63,7 @@ fn test_mint_with_only_animation_url() {
         &animation_url,
         &royalty,
         &false,
+        &None,
         &sig,
     );
 
@@ -86,7 +87,7 @@ fn test_mint_without_media_fields() {
 
     let token_id = ctx
         .client
-        .mint(&owner, &clip_id, &uri, &None, &None, &royalty, &false, &sig);
+        .mint(&owner, &clip_id, &uri, &None, &None, &royalty, &false, &None, &sig);
 
     assert_eq!(token_id, 1);
 
@@ -115,6 +116,7 @@ fn test_mint_with_invalid_image_url_fails() {
         &None,
         &royalty,
         &false,
+        &None,
         &sig,
     );
     
@@ -140,6 +142,7 @@ fn test_mint_with_invalid_animation_url_fails() {
         &invalid_animation,
         &royalty,
         &false,
+        &None,
         &sig,
     );
     
@@ -194,7 +197,7 @@ fn test_refresh_metadata_clears_image_with_empty_string() {
     let royalty = default_royalty(ctx.env, owner.clone());
 
     let token_id = ctx.client.mint(
-        &owner, &clip_id, &uri, &image, &None, &royalty, &false, &sig,
+        &owner, &clip_id, &uri, &image, &None, &royalty, &false, &None, &sig,
     );
 
     // Clear the image field

--- a/clips_nft/tests/test_new_features.rs
+++ b/clips_nft/tests/test_new_features.rs
@@ -86,7 +86,7 @@ fn test_blacklist_clip() {
     let signature = sign_mint(&env, &signer_keypair, &user, clip_id, &metadata_uri);
 
     // Mint before blacklist should work
-    let token_id = client.mint(&user, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &signature);
+    let token_id = client.mint(&user, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &None, &signature);
     assert_eq!(token_id, 1);
 
     // Blacklist the clip
@@ -105,7 +105,7 @@ fn test_blacklist_clip() {
         asset_address: None,
     };
 
-    let result = client.try_mint(&user, &(clip_id + 1), &metadata_uri2, &None, &None, &royalty2, &false, &signature2);
+    let result = client.try_mint(&user, &(clip_id + 1), &metadata_uri2, &None, &None, &royalty2, &false, &None, &signature2);
     assert!(result.is_err());
 }
 
@@ -140,6 +140,6 @@ fn test_get_clip_id() {
     };
     let signature = sign_mint(&env, &signer_keypair, &user, clip_id, &metadata_uri);
 
-    let token_id = client.mint(&user, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &signature);
+    let token_id = client.mint(&user, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &None, &signature);
     assert_eq!(client.get_clip_id(&token_id), clip_id);
 }

--- a/clips_nft/tests/upgrade_migration.rs
+++ b/clips_nft/tests/upgrade_migration.rs
@@ -641,7 +641,7 @@ fn test_upgrade_preserves_royalty_balances() {
         asset_address: Some(asset.clone()),
     };
     let token_id = client.mint(
-        &creator, &clip_id, &uri, &None, &None, &royalty, &false, &sig,
+        &creator, &clip_id, &uri, &None, &None, &royalty, &false, &None, &sig,
     );
 
     // Pay royalty to accumulate a balance.

--- a/clips_nft/tests/wallet_freighter_sim_integration.rs
+++ b/clips_nft/tests/wallet_freighter_sim_integration.rs
@@ -302,7 +302,7 @@ fn test_on_chain_state_after_mint() {
     let sig2 = sign_mint(&env, &backend.keypair, &creator.get_address(), clip_id, &metadata_uri);
     assert!(client.try_mint(
         &creator.get_address(), &clip_id, &metadata_uri, &None, &None,
-        &royalty_data, &false, &sig2
+        &royalty_data, &false, &None, &sig2
     ).is_err());
 }
 
@@ -418,7 +418,7 @@ fn test_wallet_blacklist_blocks_mint_and_transfer() {
     // Mint by bad_actor is rejected
     let sig = sign_mint(&env, &backend.keypair, &bad_actor, clip_id, &metadata_uri);
     assert!(client.try_mint(
-        &bad_actor, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &sig
+        &bad_actor, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &None, &sig
     ).is_err());
 
     // Mint by good_user succeeds
@@ -428,7 +428,7 @@ fn test_wallet_blacklist_blocks_mint_and_transfer() {
     r2.push_back(RoyaltyRecipient { recipient: good_user.clone(), basis_points: 500 });
     let royalty2 = Royalty { recipients: r2, asset_address: None };
     let sig2 = sign_mint(&env, &backend.keypair, &good_user, clip_id2, &uri2);
-    let token_id = client.mint(&good_user, &clip_id2, &uri2, &None, &None, &royalty2, &false, &sig2);
+    let token_id = client.mint(&good_user, &clip_id2, &uri2, &None, &None, &royalty2, &false, &None, &sig2);
 
     // Transfer to blacklisted wallet is rejected
     assert!(client.try_transfer(&good_user, &bad_actor, &token_id).is_err());
@@ -467,7 +467,7 @@ fn test_on_chain_approval_and_transfer_from() {
     recipients.push_back(RoyaltyRecipient { recipient: owner.clone(), basis_points: 500 });
     let royalty = Royalty { recipients, asset_address: None };
     let sig = sign_mint(&env, &backend.keypair, &owner, clip_id, &metadata_uri);
-    let token_id = client.mint(&owner, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &sig);
+    let token_id = client.mint(&owner, &clip_id, &metadata_uri, &None, &None, &royalty, &false, &None, &sig);
 
     // No approval yet
     assert_eq!(client.get_approved(&token_id), None);

--- a/contracts/clips_nft/src/index.ts
+++ b/contracts/clips_nft/src/index.ts
@@ -320,7 +320,7 @@ export interface Client {
    * * `is_soulbound` - Whether the token is soulbound (non-transferable)
    * * `signature`    - 64-byte Ed25519 signature from the backend signer
    */
-  mint: ({to, clip_id, metadata_uri, royalty, is_soulbound, signature}: {to: string, clip_id: u32, metadata_uri: string, royalty: Royalty, is_soulbound: boolean, signature: Buffer}, options?: MethodOptions) => Promise<AssembledTransaction<Result<TokenId>>>
+  mint: ({to, clip_id, metadata_uri, royalty, is_soulbound, fee_payer, signature}: {to: string, clip_id: u32, metadata_uri: string, royalty: Royalty, is_soulbound: boolean, fee_payer?: string, signature: Buffer}, options?: MethodOptions) => Promise<AssembledTransaction<Result<TokenId>>>
 
   /**
    * Construct and simulate a pause transaction. Returns an `AssembledTransaction` object which will have a `result` field containing the result of the simulation. If this transaction changes contract state, you will need to call `signAndSend()` on the returned object.


### PR DESCRIPTION
Implements contract enhancements for clips_nft including:
- Enforced max supply cap in mint and batch_mint
- Admin-only recover_token entrypoint
- Optional fee payer support for minting
- Updated TS bindings and test coverage

Closes #334
Closes #335
Closes #337