### PR TITLE
feat: #449 Create Contract Configuration Struct

### DIFF
--- a/clips_nft/Cargo.toml
+++ b/clips_nft/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "clips_nft"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/clips_nft/src/config.rs
+++ b/clips_nft/src/config.rs
@@ -1,0 +1,49 @@
+//! Global contract configuration.
+//!
+//! [`Config`] consolidates all top-level settings into a single storable
+//! struct so callers can read or update the contract state in one round-trip.
+
+use soroban_sdk::{contracttype, Address, Env};
+
+use crate::types::{DataKey, Error};
+
+/// Contract version constant — bump on breaking interface changes.
+pub const CONTRACT_VERSION: u32 = 1;
+
+/// Reusable struct that holds every global contract setting.
+///
+/// Stored under [`DataKey::Config`] in instance storage.
+#[contracttype]
+#[derive(Clone)]
+pub struct Config {
+    /// Contract owner / administrator address.
+    pub owner: Address,
+    /// Semantic version number (monotonically increasing integer).
+    pub version: u32,
+    /// Platform fee in basis points (0–1 000, i.e. 0 %–10 %).
+    pub platform_fee_bps: u32,
+    /// Default royalty in basis points applied to newly minted NFTs (0–10 000).
+    pub default_royalty_bps: u32,
+    /// When `true`, mint and transfer operations are blocked.
+    pub paused: bool,
+}
+
+/// Persist a [`Config`] snapshot to instance storage.
+///
+/// # Errors
+/// Returns [`Error::InvalidBasisPoints`] when fee or royalty limits are exceeded.
+pub fn set_config(env: &Env, config: Config) -> Result<(), Error> {
+    if config.platform_fee_bps > crate::platform_fee::MAX_PLATFORM_FEE_BPS {
+        return Err(Error::InvalidBasisPoints);
+    }
+    if config.default_royalty_bps > crate::default_royalty::MAX_ROYALTY_BPS {
+        return Err(Error::InvalidBasisPoints);
+    }
+    env.storage().instance().set(&DataKey::Config, &config);
+    Ok(())
+}
+
+/// Return the stored [`Config`], or `None` if the contract is not yet initialized.
+pub fn get_config(env: &Env) -> Option<Config> {
+    env.storage().instance().get(&DataKey::Config)
+}

--- a/clips_nft/src/default_royalty.rs
+++ b/clips_nft/src/default_royalty.rs
@@ -1,0 +1,44 @@
+//! Default royalty configuration.
+//!
+//! Stores a contract-wide default royalty percentage (in basis points) that is
+//! applied to newly minted NFTs when no per-token royalty is explicitly
+//! provided.
+//!
+//! # Storage
+//! Key: `DataKey::DefaultRoyaltyBps` (instance storage)
+//!
+//! # Limits
+//! `0` – `10_000` bps inclusive (0 % – 100 %).  
+//! Typical values are in the range 100–1 000 bps (1 %–10 %).
+
+use soroban_sdk::Env;
+
+use crate::types::{DataKey, Error};
+
+/// Absolute maximum royalty: 100 % = 10 000 basis points.
+pub const MAX_ROYALTY_BPS: u32 = 10_000;
+
+/// Factory default applied when no custom value has been set (5 % = 500 bps).
+pub const DEFAULT_ROYALTY_BPS: u32 = 500;
+
+/// Persist the default royalty in basis points.
+///
+/// # Errors
+/// Returns [`Error::InvalidBasisPoints`] when `bps > MAX_ROYALTY_BPS`.
+pub fn set_default_royalty_bps(env: &Env, bps: u32) -> Result<(), Error> {
+    if bps > MAX_ROYALTY_BPS {
+        return Err(Error::InvalidBasisPoints);
+    }
+    env.storage().instance().set(&DataKey::DefaultRoyaltyBps, &bps);
+    Ok(())
+}
+
+/// Return the stored default royalty in basis points.
+///
+/// Falls back to [`DEFAULT_ROYALTY_BPS`] (500) if never explicitly set.
+pub fn get_default_royalty_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::DefaultRoyaltyBps)
+        .unwrap_or(DEFAULT_ROYALTY_BPS)
+}

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -6,10 +6,12 @@
 
 #![no_std]
 
+mod config;
 mod default_royalty;
 mod platform_fee;
 mod types;
 
+pub use config::{get_config, set_config, Config, CONTRACT_VERSION};
 pub use default_royalty::{
     get_default_royalty_bps, set_default_royalty_bps, DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS,
 };
@@ -37,6 +39,20 @@ impl ClipCashNFT {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::NextTokenId, &0u32);
         env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    // ─── Config ───────────────────────────────────────────────────────────────
+
+    /// Persist a full [`Config`] snapshot. Admin only.
+    pub fn set_config(env: Env, admin: Address, cfg: Config) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        config::set_config(&env, cfg)
+    }
+
+    /// Return the current [`Config`], or `None` before initialization.
+    pub fn get_config(env: Env) -> Option<Config> {
+        config::get_config(&env)
     }
 
     // ─── Default Royalty ─────────────────────────────────────────────────────

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -1,0 +1,280 @@
+//! ClipCashNFT — Soroban smart contract entry point.
+//!
+//! This module is the single gateway for all public contract methods.
+//! It re-exports types and registers the contract implementation
+//! via the `#[contract]` / `#[contractimpl]` macros.
+
+#![no_std]
+
+mod types;
+
+pub use types::{DataKey, Error, MintEvent, Royalty, RoyaltyInfo, TokenData, TokenId};
+
+use soroban_sdk::{
+    contract, contractimpl, BytesN, Env, String,
+    Address,
+};
+
+#[contract]
+pub struct ClipCashNFT;
+
+#[contractimpl]
+impl ClipCashNFT {
+    // ─── Initialization ──────────────────────────────────────────────────────
+
+    /// Initialize the contract and set the admin.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::NextTokenId, &0u32);
+        env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    // ─── Signer ──────────────────────────────────────────────────────────────
+
+    /// Register or rotate the backend Ed25519 signer public key.
+    pub fn set_signer(env: Env, admin: Address, pubkey: BytesN<32>) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Signer, &pubkey);
+        Ok(())
+    }
+
+    /// Return the currently registered signer, if any.
+    pub fn get_signer(env: Env) -> Option<BytesN<32>> {
+        env.storage().instance().get(&DataKey::Signer)
+    }
+
+    // ─── Pause ───────────────────────────────────────────────────────────────
+
+    /// Pause the contract — blocks mint and transfer.
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish(("paused",), ());
+        Ok(())
+    }
+
+    /// Unpause the contract.
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish(("unpaused",), ());
+        Ok(())
+    }
+
+    /// Returns `true` if the contract is paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    // ─── Mint ────────────────────────────────────────────────────────────────
+
+    /// Mint a new NFT for a video clip.
+    pub fn mint(
+        env: Env,
+        admin: Address,
+        to: Address,
+        clip_id: u32,
+        metadata_uri: String,
+        royalty: Royalty,
+        _signature: BytesN<64>,
+    ) -> Result<TokenId, Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        Self::require_not_paused(&env)?;
+
+        if env.storage().persistent().has(&DataKey::ClipIdMinted(clip_id)) {
+            return Err(Error::ClipAlreadyMinted);
+        }
+        if royalty.basis_points > 10_000 {
+            return Err(Error::InvalidBasisPoints);
+        }
+
+        let token_id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextTokenId)
+            .unwrap_or(0);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(token_id), &TokenData { owner: to.clone(), clip_id });
+        env.storage()
+            .persistent()
+            .set(&DataKey::Metadata(token_id), &metadata_uri);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Royalty(token_id), &royalty);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ClipIdMinted(clip_id), &token_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextTokenId, &(token_id + 1));
+
+        env.events().publish(
+            ("mint",),
+            MintEvent {
+                to,
+                clip_id,
+                token_id,
+                metadata_uri,
+            },
+        );
+        Ok(token_id)
+    }
+
+    // ─── Transfer / Burn ─────────────────────────────────────────────────────
+
+    /// Transfer NFT ownership.
+    pub fn transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: TokenId,
+    ) -> Result<(), Error> {
+        from.require_auth();
+        Self::require_not_paused(&env)?;
+        let mut data = Self::get_token_data(&env, token_id)?;
+        if data.owner != from {
+            return Err(Error::Unauthorized);
+        }
+        data.owner = to;
+        env.storage().persistent().set(&DataKey::Token(token_id), &data);
+        Ok(())
+    }
+
+    /// Burn an NFT. Only the current owner may burn.
+    pub fn burn(env: Env, owner: Address, token_id: TokenId) -> Result<(), Error> {
+        owner.require_auth();
+        let data = Self::get_token_data(&env, token_id)?;
+        if data.owner != owner {
+            return Err(Error::Unauthorized);
+        }
+        env.storage().persistent().remove(&DataKey::Token(token_id));
+        env.storage().persistent().remove(&DataKey::Metadata(token_id));
+        env.storage().persistent().remove(&DataKey::Royalty(token_id));
+        Ok(())
+    }
+
+    // ─── Queries ─────────────────────────────────────────────────────────────
+
+    /// Returns the owner of a token.
+    pub fn owner_of(env: Env, token_id: TokenId) -> Result<Address, Error> {
+        Ok(Self::get_token_data(&env, token_id)?.owner)
+    }
+
+    /// Returns the metadata URI of a token.
+    pub fn token_uri(env: Env, token_id: TokenId) -> Result<String, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Metadata(token_id))
+            .ok_or(Error::TokenNotFound)
+    }
+
+    /// Alias for `token_uri`.
+    pub fn get_metadata(env: Env, token_id: TokenId) -> Result<String, Error> {
+        Self::token_uri(env, token_id)
+    }
+
+    /// Look up token ID by clip ID.
+    pub fn clip_token_id(env: Env, clip_id: u32) -> Result<TokenId, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ClipIdMinted(clip_id))
+            .ok_or(Error::TokenNotFound)
+    }
+
+    /// Returns the royalty struct for a token.
+    pub fn get_royalty(env: Env, token_id: TokenId) -> Result<Royalty, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Royalty(token_id))
+            .ok_or(Error::TokenNotFound)
+    }
+
+    /// Returns royalty receiver and computed amount for a given sale price.
+    pub fn royalty_info(
+        env: Env,
+        token_id: TokenId,
+        sale_price: i128,
+    ) -> Result<RoyaltyInfo, Error> {
+        let r = Self::get_royalty(env, token_id)?;
+        let amount = sale_price * r.basis_points as i128 / 10_000;
+        Ok(RoyaltyInfo {
+            receiver: r.recipient,
+            royalty_amount: amount,
+            asset_address: r.asset_address,
+        })
+    }
+
+    /// Update royalty config for a token. Admin only.
+    pub fn set_royalty(
+        env: Env,
+        admin: Address,
+        token_id: TokenId,
+        new_royalty: Royalty,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        if new_royalty.basis_points > 10_000 {
+            return Err(Error::InvalidBasisPoints);
+        }
+        if !env.storage().persistent().has(&DataKey::Token(token_id)) {
+            return Err(Error::TokenNotFound);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::Royalty(token_id), &new_royalty);
+        Ok(())
+    }
+
+    /// Returns total minted token count.
+    pub fn total_supply(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::NextTokenId).unwrap_or(0)
+    }
+
+    /// Returns true if the token exists.
+    pub fn exists(env: Env, token_id: TokenId) -> bool {
+        env.storage().persistent().has(&DataKey::Token(token_id))
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────────────
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if *caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn require_not_paused(env: &Env) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            return Err(Error::ContractPaused);
+        }
+        Ok(())
+    }
+
+    fn get_token_data(env: &Env, token_id: TokenId) -> Result<TokenData, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Token(token_id))
+            .ok_or(Error::TokenNotFound)
+    }
+}

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -6,9 +6,13 @@
 
 #![no_std]
 
+mod default_royalty;
 mod platform_fee;
 mod types;
 
+pub use default_royalty::{
+    get_default_royalty_bps, set_default_royalty_bps, DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS,
+};
 pub use platform_fee::{get_platform_fee, set_platform_fee, MAX_PLATFORM_FEE_BPS};
 pub use types::{DataKey, Error, MintEvent, Royalty, RoyaltyInfo, TokenData, TokenId};
 
@@ -33,6 +37,21 @@ impl ClipCashNFT {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::NextTokenId, &0u32);
         env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    // ─── Default Royalty ─────────────────────────────────────────────────────
+
+    /// Set the contract-wide default royalty in basis points (max 10 000 = 100 %).
+    /// Admin only.
+    pub fn set_default_royalty_bps(env: Env, admin: Address, bps: u32) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        default_royalty::set_default_royalty_bps(&env, bps)
+    }
+
+    /// Return the default royalty in basis points (defaults to 500 = 5 %).
+    pub fn get_default_royalty_bps(env: Env) -> u32 {
+        default_royalty::get_default_royalty_bps(&env)
     }
 
     // ─── Platform Fee ────────────────────────────────────────────────────────

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -6,8 +6,10 @@
 
 #![no_std]
 
+mod platform_fee;
 mod types;
 
+pub use platform_fee::{get_platform_fee, set_platform_fee, MAX_PLATFORM_FEE_BPS};
 pub use types::{DataKey, Error, MintEvent, Royalty, RoyaltyInfo, TokenData, TokenId};
 
 use soroban_sdk::{
@@ -31,6 +33,21 @@ impl ClipCashNFT {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::NextTokenId, &0u32);
         env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    // ─── Platform Fee ────────────────────────────────────────────────────────
+
+    /// Set the platform fee in basis points (max 1 000 = 10 %).
+    /// Admin only.
+    pub fn set_platform_fee(env: Env, admin: Address, fee_bps: u32) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        platform_fee::set_platform_fee(&env, fee_bps)
+    }
+
+    /// Return the current platform fee in basis points.
+    pub fn get_platform_fee(env: Env) -> u32 {
+        platform_fee::get_platform_fee(&env)
     }
 
     // ─── Signer ──────────────────────────────────────────────────────────────

--- a/clips_nft/src/platform_fee.rs
+++ b/clips_nft/src/platform_fee.rs
@@ -1,0 +1,37 @@
+//! Platform fee configuration.
+//!
+//! Stores the platform fee in basis points (bps) that applies to all
+//! marketplace transactions. Maximum allowed fee is 1 000 bps (10 %).
+//!
+//! # Storage
+//! Key: `DataKey::PlatformFee` (instance storage)
+//!
+//! # Limits
+//! `0` – `1_000` bps inclusive (0 % – 10 %)
+
+use soroban_sdk::Env;
+
+use crate::types::{DataKey, Error};
+
+/// Maximum platform fee: 10 % = 1 000 basis points.
+pub const MAX_PLATFORM_FEE_BPS: u32 = 1_000;
+
+/// Store the platform fee in basis points.
+///
+/// # Errors
+/// Returns [`Error::InvalidBasisPoints`] if `fee_bps > MAX_PLATFORM_FEE_BPS`.
+pub fn set_platform_fee(env: &Env, fee_bps: u32) -> Result<(), Error> {
+    if fee_bps > MAX_PLATFORM_FEE_BPS {
+        return Err(Error::InvalidBasisPoints);
+    }
+    env.storage().instance().set(&DataKey::PlatformFee, &fee_bps);
+    Ok(())
+}
+
+/// Return the current platform fee in basis points (defaults to `0`).
+pub fn get_platform_fee(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::PlatformFee)
+        .unwrap_or(0)
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -46,6 +46,7 @@ pub enum DataKey {
     ClipIdMinted(u32),
     PlatformFee,
     DefaultRoyaltyBps,
+    Config,
 }
 
 #[contracttype]

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -1,0 +1,61 @@
+use soroban_sdk::{contracttype, Address, String};
+
+pub type TokenId = u32;
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TokenData {
+    pub owner: Address,
+    pub clip_id: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Royalty {
+    pub recipient: Address,
+    pub basis_points: u32,
+    pub asset_address: Option<Address>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RoyaltyInfo {
+    pub receiver: Address,
+    pub royalty_amount: i128,
+    pub asset_address: Option<Address>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct MintEvent {
+    pub to: Address,
+    pub clip_id: u32,
+    pub token_id: TokenId,
+    pub metadata_uri: String,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    NextTokenId,
+    Paused,
+    Signer,
+    Token(u32),
+    Metadata(u32),
+    Royalty(u32),
+    ClipIdMinted(u32),
+}
+
+#[contracttype]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    ContractPaused = 4,
+    NotPaused = 5,
+    TokenNotFound = 6,
+    ClipAlreadyMinted = 7,
+    SignerNotSet = 8,
+    InvalidSignature = 9,
+    InvalidBasisPoints = 10,
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -44,6 +44,8 @@ pub enum DataKey {
     Metadata(u32),
     Royalty(u32),
     ClipIdMinted(u32),
+    PlatformFee,
+    DefaultRoyaltyBps,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Closes #449

Introduces a `Config` struct that consolidates all global contract settings into a single storable unit, allowing callers to read or update the full contract configuration in one round-trip.

## Changes

### `clips_nft/src/config.rs` (new)

```rust
pub const CONTRACT_VERSION: u32 = 1;

#[contracttype]
pub struct Config {
    pub owner: Address,            // contract owner / admin
    pub version: u32,              // interface version
    pub platform_fee_bps: u32,     // marketplace fee (0–1 000)
    pub default_royalty_bps: u32,  // default NFT royalty (0–10 000)
    pub paused: bool,              // pause state
}

pub fn set_config(env: &Env, config: Config) -> Result<(), Error>
pub fn get_config(env: &Env) -> Option<Config>
```

- `set_config` validates `platform_fee_bps ≤ 1 000` and `default_royalty_bps ≤ 10 000`
- `get_config` returns `None` before the contract is initialized
- Stored under `DataKey::Config` in instance storage

### `clips_nft/src/types.rs`

- Added `DataKey::Config` variant

### `clips_nft/src/lib.rs`

Two new entrypoints:

| Method | Auth | Description |
|---|---|---|
| `set_config(admin, cfg)` | admin | Validate and store full Config snapshot |
| `get_config()` | — | Return current Config or None |

## Config Fields

| Field | Type | Constraint | Description |
|---|---|---|---|
| `owner` | `Address` | — | Contract owner / admin |
| `version` | `u32` | — | Interface version number |
| `platform_fee_bps` | `u32` | ≤ 1 000 | Platform fee (0–10 %) |
| `default_royalty_bps` | `u32` | ≤ 10 000 | Default royalty (0–100 %) |
| `paused` | `bool` | — | Contract pause state |

## Acceptance Criteria

- [x] `Config` struct created with `#[contracttype]`
- [x] Includes `owner` field
- [x] Includes `version` field
- [x] Includes `platform_fee_bps` (platform fee)
- [x] Includes `default_royalty_bps` (royalty settings)
- [x] Includes `paused` state