### PR TITLE
feat: add royalty recipient, history, platform revenue, and collection supply storage

### DIFF
--- a/clips_nft/src/collection_supply.rs
+++ b/clips_nft/src/collection_supply.rs
@@ -1,0 +1,26 @@
+//! Collection supply storage.
+//!
+//! Tracks the number of NFTs minted per collection.
+//!
+//! # Storage
+//! Key: `DataKey::CollectionSupply(collection_id)` (persistent storage)
+
+use soroban_sdk::Env;
+
+use crate::types::DataKey;
+
+/// Increment the minted supply counter for the given collection by one.
+pub fn increment_collection_supply(env: &Env, collection_id: u32) {
+    let current = get_collection_supply(env, collection_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CollectionSupply(collection_id), &(current + 1));
+}
+
+/// Return the current minted supply for a collection (defaults to `0`).
+pub fn get_collection_supply(env: &Env, collection_id: u32) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CollectionSupply(collection_id))
+        .unwrap_or(0)
+}

--- a/clips_nft/src/platform_revenue.rs
+++ b/clips_nft/src/platform_revenue.rs
@@ -1,0 +1,33 @@
+//! Platform revenue storage.
+//!
+//! Tracks cumulative platform revenue generated from fees.
+//!
+//! # Storage
+//! Key: `DataKey::PlatformRevenue` (instance storage)
+
+use soroban_sdk::Env;
+
+use crate::types::DataKey;
+
+/// Overwrite the stored platform revenue with `amount`.
+pub fn save_platform_revenue(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PlatformRevenue, &amount);
+}
+
+/// Add `delta` to the current platform revenue total.
+pub fn update_platform_revenue(env: &Env, delta: i128) {
+    let current = get_platform_revenue(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::PlatformRevenue, &(current + delta));
+}
+
+/// Return the current cumulative platform revenue (defaults to `0`).
+pub fn get_platform_revenue(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::PlatformRevenue)
+        .unwrap_or(0)
+}

--- a/clips_nft/src/royalty_history.rs
+++ b/clips_nft/src/royalty_history.rs
@@ -1,0 +1,39 @@
+//! Royalty payment history storage.
+//!
+//! Tracks royalty payment records per token. Each entry captures the
+//! recipient, amount, and ledger timestamp at the time of payment.
+//!
+//! # Storage
+//! Key: `DataKey::RoyaltyHistory(token_id)` (persistent storage)
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{DataKey, RoyaltyPayment, TokenId};
+
+/// Append a royalty payment record for the given token.
+pub fn record_royalty_payment(
+    env: &Env,
+    token_id: TokenId,
+    recipient: Address,
+    amount: i128,
+    timestamp: u64,
+) {
+    let mut history = get_royalty_history(env, token_id);
+    history.push_back(RoyaltyPayment {
+        token_id,
+        recipient,
+        amount,
+        timestamp,
+    });
+    env.storage()
+        .persistent()
+        .set(&DataKey::RoyaltyHistory(token_id), &history);
+}
+
+/// Return all royalty payment records for a token (empty if none recorded).
+pub fn get_royalty_history(env: &Env, token_id: TokenId) -> Vec<RoyaltyPayment> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RoyaltyHistory(token_id))
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/clips_nft/src/royalty_recipient.rs
+++ b/clips_nft/src/royalty_recipient.rs
@@ -1,0 +1,38 @@
+//! Royalty recipient storage.
+//!
+//! Stores royalty recipient addresses separately from the full `Royalty`
+//! struct, allowing lightweight recipient lookups and updates.
+//!
+//! # Storage
+//! Key: `DataKey::RoyaltyRecipient(token_id)` (persistent storage)
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, Error, TokenId};
+
+/// Persist the royalty recipient for a given token.
+///
+/// Creates or overwrites the stored address, acting as both save and update.
+///
+/// # Errors
+/// Returns [`Error::TokenNotFound`] if the token does not exist.
+pub fn set_royalty_recipient(
+    env: &Env,
+    token_id: TokenId,
+    recipient: Address,
+) -> Result<(), Error> {
+    if !env.storage().persistent().has(&DataKey::Token(token_id)) {
+        return Err(Error::TokenNotFound);
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::RoyaltyRecipient(token_id), &recipient);
+    Ok(())
+}
+
+/// Return the royalty recipient for a given token, or `None` if not set.
+pub fn get_royalty_recipient(env: &Env, token_id: TokenId) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RoyaltyRecipient(token_id))
+}


### PR DESCRIPTION

[Storage] Create Royalty Recipient Storage
Fixes #512

[Storage] Create Royalty History Storage
Fixes #513

[Storage] Create Platform Revenue Storage
Fixes #514

[Storage] Create Collection Supply Storage
Fixes #515