### PR TITLE
feat: configuration error types, guard, validator, and payment currencies

### DIFF
--- a/clips_nft/src/config_guard.rs
+++ b/clips_nft/src/config_guard.rs
@@ -1,0 +1,33 @@
+//! Configuration update guard (Issue #485).
+//!
+//! Restricts configuration updates to authorized administrators.
+//! Provides a reusable guard that validates caller identity before
+//! allowing any configuration mutation.
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, Error};
+
+/// Validate that the caller is the contract owner/admin and require auth.
+///
+/// This is the single entry point for all configuration update authorization.
+/// It checks:
+/// 1. The contract has been initialized (admin exists).
+/// 2. The caller matches the stored admin address.
+/// 3. The caller has signed the invocation (`require_auth`).
+///
+/// # Errors
+/// - [`Error::NotInitialized`] if the contract has not been initialized.
+/// - [`Error::UnauthorizedConfigurationUpdate`] if the caller is not admin.
+pub fn require_config_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    if *caller != admin {
+        return Err(Error::UnauthorizedConfigurationUpdate);
+    }
+    caller.require_auth();
+    Ok(())
+}

--- a/clips_nft/src/config_validator.rs
+++ b/clips_nft/src/config_validator.rs
@@ -1,0 +1,83 @@
+//! Configuration validator (Issue #483).
+//!
+//! Reusable validator for every configuration update.
+//! Validates fees, addresses, URIs, collection limits, and royalty percentages.
+
+use soroban_sdk::{Address, Env, String};
+
+use crate::default_royalty::MAX_ROYALTY_BPS;
+use crate::platform_fee::MAX_PLATFORM_FEE_BPS;
+use crate::types::Error;
+
+/// Maximum collection size limit (prevents unbounded storage growth).
+pub const MAX_COLLECTION_LIMIT: u32 = 100_000;
+
+/// Validate a platform fee value in basis points.
+///
+/// Must be in range `[0, MAX_PLATFORM_FEE_BPS]` (0–10 %).
+pub fn validate_fee(fee_bps: u32) -> Result<(), Error> {
+    if fee_bps > MAX_PLATFORM_FEE_BPS {
+        return Err(Error::InvalidFee);
+    }
+    Ok(())
+}
+
+/// Validate a royalty percentage in basis points.
+///
+/// Must be in range `[0, MAX_ROYALTY_BPS]` (0–100 %).
+pub fn validate_royalty_bps(bps: u32) -> Result<(), Error> {
+    if bps > MAX_ROYALTY_BPS {
+        return Err(Error::InvalidBasisPoints);
+    }
+    Ok(())
+}
+
+/// Validate that an address is present (non-None check for Option<Address>).
+///
+/// For direct Address values this always succeeds since Soroban addresses
+/// are structurally valid by construction. Use this for Option<Address> fields.
+pub fn validate_address_present(addr: &Option<Address>) -> Result<(), Error> {
+    if addr.is_none() {
+        return Err(Error::InvalidAddress);
+    }
+    Ok(())
+}
+
+/// Validate a metadata URI string.
+///
+/// Rejects empty strings.
+pub fn validate_uri(uri: &String) -> Result<(), Error> {
+    if uri.len() == 0 {
+        return Err(Error::InvalidURI);
+    }
+    Ok(())
+}
+
+/// Validate a collection limit.
+///
+/// Must be in range `[1, MAX_COLLECTION_LIMIT]`.
+pub fn validate_collection_limit(limit: u32) -> Result<(), Error> {
+    if limit == 0 || limit > MAX_COLLECTION_LIMIT {
+        return Err(Error::InvalidLimit);
+    }
+    Ok(())
+}
+
+/// Validate a full Config struct before persisting.
+///
+/// Checks platform fee, default royalty, and owner address.
+pub fn validate_config(_env: &Env, config: &crate::config::Config) -> Result<(), Error> {
+    // Validate platform fee range
+    validate_fee(config.platform_fee_bps)?;
+
+    // Validate default royalty range
+    validate_royalty_bps(config.default_royalty_bps)?;
+
+    // Owner address is always valid by Soroban type system — no extra check needed.
+    // Version must be > 0
+    if config.version == 0 {
+        return Err(Error::InvalidLimit);
+    }
+
+    Ok(())
+}

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -7,7 +7,10 @@
 #![no_std]
 
 mod config;
+mod config_guard;
+mod config_validator;
 mod default_royalty;
+mod payment_currency;
 mod platform_fee;
 mod types;
 
@@ -16,6 +19,12 @@ pub use default_royalty::{
     get_default_royalty_bps, set_default_royalty_bps, DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS,
 };
 pub use platform_fee::{get_platform_fee, set_platform_fee, MAX_PLATFORM_FEE_BPS};
+pub use config_guard::require_config_admin;
+pub use config_validator::{
+    validate_collection_limit, validate_config, validate_fee, validate_royalty_bps, validate_uri,
+    MAX_COLLECTION_LIMIT,
+};
+pub use payment_currency::{add_currency, get_currencies, is_supported, remove_currency};
 pub use types::{DataKey, Error, MintEvent, Royalty, RoyaltyInfo, TokenData, TokenId};
 
 use soroban_sdk::{
@@ -44,9 +53,10 @@ impl ClipCashNFT {
     // ─── Config ───────────────────────────────────────────────────────────────
 
     /// Persist a full [`Config`] snapshot. Admin only.
+    /// Uses the configuration guard and validator.
     pub fn set_config(env: Env, admin: Address, cfg: Config) -> Result<(), Error> {
-        Self::require_admin(&env, &admin)?;
-        admin.require_auth();
+        config_guard::require_config_admin(&env, &admin)?;
+        config_validator::validate_config(&env, &cfg)?;
         config::set_config(&env, cfg)
     }
 
@@ -58,10 +68,9 @@ impl ClipCashNFT {
     // ─── Default Royalty ─────────────────────────────────────────────────────
 
     /// Set the contract-wide default royalty in basis points (max 10 000 = 100 %).
-    /// Admin only.
+    /// Admin only. Uses configuration guard.
     pub fn set_default_royalty_bps(env: Env, admin: Address, bps: u32) -> Result<(), Error> {
-        Self::require_admin(&env, &admin)?;
-        admin.require_auth();
+        config_guard::require_config_admin(&env, &admin)?;
         default_royalty::set_default_royalty_bps(&env, bps)
     }
 
@@ -75,14 +84,37 @@ impl ClipCashNFT {
     /// Set the platform fee in basis points (max 1 000 = 10 %).
     /// Admin only.
     pub fn set_platform_fee(env: Env, admin: Address, fee_bps: u32) -> Result<(), Error> {
-        Self::require_admin(&env, &admin)?;
-        admin.require_auth();
+        config_guard::require_config_admin(&env, &admin)?;
         platform_fee::set_platform_fee(&env, fee_bps)
     }
 
     /// Return the current platform fee in basis points.
     pub fn get_platform_fee(env: Env) -> u32 {
         platform_fee::get_platform_fee(&env)
+    }
+
+    // ─── Payment Currencies ────────────────────────────────────────────────
+
+    /// Add a supported payment currency. Admin only.
+    pub fn add_currency(env: Env, admin: Address, currency: Address) -> Result<(), Error> {
+        config_guard::require_config_admin(&env, &admin)?;
+        payment_currency::add_currency(&env, currency)
+    }
+
+    /// Remove a supported payment currency. Admin only.
+    pub fn remove_currency(env: Env, admin: Address, currency: Address) -> Result<(), Error> {
+        config_guard::require_config_admin(&env, &admin)?;
+        payment_currency::remove_currency(&env, &currency)
+    }
+
+    /// Get the list of supported payment currencies.
+    pub fn get_currencies(env: Env) -> soroban_sdk::Vec<Address> {
+        payment_currency::get_currencies(&env)
+    }
+
+    /// Check if a currency is supported for payments.
+    pub fn is_currency_supported(env: Env, currency: Address) -> bool {
+        payment_currency::is_supported(&env, &currency)
     }
 
     // ─── Signer ──────────────────────────────────────────────────────────────

--- a/clips_nft/src/payment_currency.rs
+++ b/clips_nft/src/payment_currency.rs
@@ -1,0 +1,79 @@
+//! Supported payment currency configuration (Issue #480).
+//!
+//! Allows administrators to define accepted payment currencies.
+//! Provides storage, deduplication, getter, and admin update.
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{DataKey, Error};
+
+/// Add a payment currency to the supported list.
+///
+/// Prevents duplicates — returns [`Error::DuplicateCurrency`] if already present.
+pub fn add_currency(env: &Env, currency: Address) -> Result<(), Error> {
+    let mut currencies = get_currencies(env);
+
+    // Check for duplicates
+    for i in 0..currencies.len() {
+        if let Some(c) = currencies.get(i) {
+            if c == currency {
+                return Err(Error::DuplicateCurrency);
+            }
+        }
+    }
+
+    currencies.push_back(currency);
+    env.storage()
+        .instance()
+        .set(&DataKey::SupportedCurrencies, &currencies);
+    Ok(())
+}
+
+/// Remove a payment currency from the supported list.
+///
+/// Returns [`Error::CurrencyNotFound`] if the currency is not in the list.
+pub fn remove_currency(env: &Env, currency: &Address) -> Result<(), Error> {
+    let currencies = get_currencies(env);
+    let mut new_list = Vec::new(env);
+    let mut found = false;
+
+    for i in 0..currencies.len() {
+        if let Some(c) = currencies.get(i) {
+            if c == *currency {
+                found = true;
+            } else {
+                new_list.push_back(c);
+            }
+        }
+    }
+
+    if !found {
+        return Err(Error::CurrencyNotFound);
+    }
+
+    env.storage()
+        .instance()
+        .set(&DataKey::SupportedCurrencies, &new_list);
+    Ok(())
+}
+
+/// Get the list of supported payment currencies.
+pub fn get_currencies(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::SupportedCurrencies)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Check if a currency is in the supported list.
+pub fn is_supported(env: &Env, currency: &Address) -> bool {
+    let currencies = get_currencies(env);
+    for i in 0..currencies.len() {
+        if let Some(c) = currencies.get(i) {
+            if c == *currency {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contracterror, contracttype, Address, String};
 
 pub type TokenId = u32;
 
@@ -47,9 +47,13 @@ pub enum DataKey {
     PlatformFee,
     DefaultRoyaltyBps,
     Config,
+    /// List of supported payment currency addresses.
+    SupportedCurrencies,
 }
 
-#[contracttype]
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
 pub enum Error {
     AlreadyInitialized = 1,
     NotInitialized = 2,
@@ -61,4 +65,19 @@ pub enum Error {
     SignerNotSet = 8,
     InvalidSignature = 9,
     InvalidBasisPoints = 10,
+    // ── Configuration Errors (Issue #486) ────────────────────────────────
+    /// Fee value is outside the allowed range.
+    InvalidFee = 11,
+    /// Address is invalid or empty.
+    InvalidAddress = 12,
+    /// Metadata URI is empty or malformed.
+    InvalidURI = 13,
+    /// Collection limit is zero or exceeds the maximum.
+    InvalidLimit = 14,
+    /// Caller is not authorized to update configuration.
+    UnauthorizedConfigurationUpdate = 15,
+    /// Currency already exists in the supported list.
+    DuplicateCurrency = 16,
+    /// Currency not found in the supported list.
+    CurrencyNotFound = 17,
 }

--- a/clips_nft/tests/config_features.rs
+++ b/clips_nft/tests/config_features.rs
@@ -1,0 +1,297 @@
+#![cfg(test)]
+
+use clips_nft::{
+    ClipCashNFT, ClipCashNFTClient, Config, Error,
+    MAX_COLLECTION_LIMIT,
+};
+use soroban_sdk::{
+    testutils::Address as _,
+    Address, Env, String,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, ClipCashNFTClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ClipCashNFT, ());
+    let client = ClipCashNFTClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    (env, client, admin)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #486 — Configuration Error Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_invalid_fee_error_on_high_platform_fee() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 2_000, // exceeds MAX_PLATFORM_FEE_BPS (1_000)
+        default_royalty_bps: 500,
+        paused: false,
+    };
+    // set_config should fail with InvalidFee via the validator
+    let result = client.try_set_config(&admin, &cfg);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_invalid_basis_points_error_on_high_royalty() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 100,
+        default_royalty_bps: 15_000, // exceeds MAX_ROYALTY_BPS (10_000)
+        paused: false,
+    };
+    let result = client.try_set_config(&admin, &cfg);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_invalid_limit_error_on_zero_version() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 0, // must be > 0
+        platform_fee_bps: 100,
+        default_royalty_bps: 500,
+        paused: false,
+    };
+    let result = client.try_set_config(&admin, &cfg);
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #485 — Configuration Update Guard
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_config_guard_allows_admin() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 100,
+        default_royalty_bps: 500,
+        paused: false,
+    };
+    // Admin should succeed
+    client.set_config(&admin, &cfg);
+    let stored = client.get_config();
+    assert!(stored.is_some());
+    assert_eq!(stored.unwrap().platform_fee_bps, 100);
+}
+
+#[test]
+fn test_config_guard_rejects_non_admin() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 100,
+        default_royalty_bps: 500,
+        paused: false,
+    };
+    // Non-admin should fail with UnauthorizedConfigurationUpdate
+    let result = client.try_set_config(&non_admin, &cfg);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_config_guard_on_set_default_royalty() {
+    let (env, client, admin) = setup();
+    // Admin should succeed
+    client.set_default_royalty_bps(&admin, &500);
+    assert_eq!(client.get_default_royalty_bps(), 500);
+
+    // Non-admin should fail
+    let non_admin = Address::generate(&env);
+    let result = client.try_set_default_royalty_bps(&non_admin, &500);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_config_guard_on_set_platform_fee() {
+    let (env, client, admin) = setup();
+    // Admin should succeed
+    client.set_platform_fee(&admin, &200);
+    assert_eq!(client.get_platform_fee(), 200);
+
+    // Non-admin should fail
+    let non_admin = Address::generate(&env);
+    let result = client.try_set_platform_fee(&non_admin, &200);
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #483 — Configuration Validator
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_validator_accepts_valid_config() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 500,
+        default_royalty_bps: 1_000,
+        paused: false,
+    };
+    client.set_config(&admin, &cfg);
+    let stored = client.get_config().unwrap();
+    assert_eq!(stored.platform_fee_bps, 500);
+    assert_eq!(stored.default_royalty_bps, 1_000);
+}
+
+#[test]
+fn test_validator_rejects_platform_fee_above_max() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 1_001, // MAX is 1_000
+        default_royalty_bps: 500,
+        paused: false,
+    };
+    let result = client.try_set_config(&admin, &cfg);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_validator_rejects_royalty_above_max() {
+    let (env, client, admin) = setup();
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 100,
+        default_royalty_bps: 10_001, // MAX is 10_000
+        paused: false,
+    };
+    let result = client.try_set_config(&admin, &cfg);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_validator_boundary_values_accepted() {
+    let (env, client, admin) = setup();
+    // Exactly at max platform fee and max royalty
+    let cfg = Config {
+        owner: admin.clone(),
+        version: 1,
+        platform_fee_bps: 1_000, // exactly MAX_PLATFORM_FEE_BPS
+        default_royalty_bps: 10_000, // exactly MAX_ROYALTY_BPS
+        paused: false,
+    };
+    client.set_config(&admin, &cfg);
+    let stored = client.get_config().unwrap();
+    assert_eq!(stored.platform_fee_bps, 1_000);
+    assert_eq!(stored.default_royalty_bps, 10_000);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #480 — Supported Payment Currency Configuration
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_add_currency_success() {
+    let (env, client, admin) = setup();
+    let currency = Address::generate(&env);
+    client.add_currency(&admin, &currency);
+
+    let currencies = client.get_currencies();
+    assert_eq!(currencies.len(), 1);
+    assert!(client.is_currency_supported(&currency));
+}
+
+#[test]
+fn test_add_multiple_currencies() {
+    let (env, client, admin) = setup();
+    let c1 = Address::generate(&env);
+    let c2 = Address::generate(&env);
+    let c3 = Address::generate(&env);
+
+    client.add_currency(&admin, &c1);
+    client.add_currency(&admin, &c2);
+    client.add_currency(&admin, &c3);
+
+    let currencies = client.get_currencies();
+    assert_eq!(currencies.len(), 3);
+    assert!(client.is_currency_supported(&c1));
+    assert!(client.is_currency_supported(&c2));
+    assert!(client.is_currency_supported(&c3));
+}
+
+#[test]
+fn test_add_duplicate_currency_fails() {
+    let (env, client, admin) = setup();
+    let currency = Address::generate(&env);
+    client.add_currency(&admin, &currency);
+
+    // Adding same currency again should fail
+    let result = client.try_add_currency(&admin, &currency);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_remove_currency_success() {
+    let (env, client, admin) = setup();
+    let currency = Address::generate(&env);
+    client.add_currency(&admin, &currency);
+    assert!(client.is_currency_supported(&currency));
+
+    client.remove_currency(&admin, &currency);
+    assert!(!client.is_currency_supported(&currency));
+    assert_eq!(client.get_currencies().len(), 0);
+}
+
+#[test]
+fn test_remove_nonexistent_currency_fails() {
+    let (env, client, admin) = setup();
+    let currency = Address::generate(&env);
+
+    let result = client.try_remove_currency(&admin, &currency);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_currency_non_admin_cannot_add() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let currency = Address::generate(&env);
+
+    let result = client.try_add_currency(&non_admin, &currency);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_currency_non_admin_cannot_remove() {
+    let (env, client, admin) = setup();
+    let non_admin = Address::generate(&env);
+    let currency = Address::generate(&env);
+
+    client.add_currency(&admin, &currency);
+    let result = client.try_remove_currency(&non_admin, &currency);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_currencies_empty_by_default() {
+    let (env, client, admin) = setup();
+    let currencies = client.get_currencies();
+    assert_eq!(currencies.len(), 0);
+}
+
+#[test]
+fn test_is_currency_supported_false_for_unknown() {
+    let (env, client, admin) = setup();
+    let currency = Address::generate(&env);
+    assert!(!client.is_currency_supported(&currency));
+}


### PR DESCRIPTION
Closes #486
Closes #485
Closes #483
Closes #480

## Summary

- **Configuration Error Types (#486):** Added `InvalidFee`, `InvalidAddress`, `InvalidURI`, `InvalidLimit`, `UnauthorizedConfigurationUpdate`, `DuplicateCurrency`, and `CurrencyNotFound` error variants using the `#[contracterror]` macro for proper Soroban error handling
- **Configuration Update Guard (#485):** Created `config_guard.rs` with `require_config_admin()` that validates admin identity and calls `require_auth()` before allowing configuration mutations. Returns `UnauthorizedConfigurationUpdate` for non-admin callers
- **Configuration Validator (#483):** Created `config_validator.rs` with reusable validators for fees (`validate_fee`), royalty basis points (`validate_royalty_bps`), addresses (`validate_address_present`), URIs (`validate_uri`), collection limits (`validate_collection_limit`), and full config structs (`validate_config`)
- **Supported Payment Currency Configuration (#480):** Created `payment_currency.rs` with `add_currency` (with duplicate prevention), `remove_currency`, `get_currencies`, and `is_supported` functions. Added `SupportedCurrencies` DataKey variant. Exposed as public contract methods with admin-only access via config guard

## Changes

- `clips_nft/src/types.rs` — Migrated `Error` enum from `#[contracttype]` to `#[contracterror]` with `#[repr(u32)]`, added 7 new error variants and `SupportedCurrencies` DataKey
- `clips_nft/src/config_guard.rs` — New module for admin authorization guard
- `clips_nft/src/config_validator.rs` — New module for configuration validation
- `clips_nft/src/payment_currency.rs` — New module for payment currency management
- `clips_nft/src/lib.rs` — Registered new modules, updated `set_config`, `set_default_royalty_bps`, `set_platform_fee` to use config guard, added currency management public methods
- `clips_nft/tests/config_features.rs` — 20 tests covering all new features

## Test plan

- [x] All 20 new tests pass (`cargo test --test config_features`)
- [x] `cargo check` passes with no errors
- [x] Error types correctly use `#[contracterror]` with `#[repr(u32)]`
- [x] Config guard rejects non-admin callers
- [x] Validator rejects out-of-range fees, royalties, and zero-version configs
- [x] Currency add/remove/get/is_supported work correctly
- [x] Duplicate currency prevention works
- [x] Boundary values (max fee, max royalty) are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)