### PR TITLE
feat: configuration service, batch/collection size limits, and update events

### DIFF
--- a/clips_nft/src/config.rs
+++ b/clips_nft/src/config.rs
@@ -3,12 +3,16 @@
 //! [`Config`] consolidates all top-level settings into a single storable
 //! struct so callers can read or update the contract state in one round-trip.
 
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Env, String};
 
 use crate::types::{DataKey, Error};
 
 /// Contract version constant — bump on breaking interface changes.
 pub const CONTRACT_VERSION: u32 = 1;
+
+/// Default and limit constants for batch/collection size.
+pub const MAX_BATCH_MINT_SIZE: u32 = 50;
+pub const MAX_COLLECTION_SIZE: u32 = 10_000;
 
 /// Reusable struct that holds every global contract setting.
 ///
@@ -26,24 +30,100 @@ pub struct Config {
     pub default_royalty_bps: u32,
     /// When `true`, mint and transfer operations are blocked.
     pub paused: bool,
+    /// Maximum number of NFTs mintable in a single batch call (1–100).
+    pub max_batch_mint_size: u32,
+    /// Maximum total NFTs in a collection (1–100 000).
+    pub max_collection_size: u32,
 }
 
-/// Persist a [`Config`] snapshot to instance storage.
+/// Event emitted whenever a config value changes.
+#[contracttype]
+#[derive(Clone)]
+pub struct ConfigUpdateEvent {
+    pub key: String,
+    pub old_value: u32,
+    pub new_value: u32,
+    pub updater: Address,
+}
+
+/// Persist a [`Config`] snapshot to instance storage, emitting events for changed fields.
 ///
 /// # Errors
-/// Returns [`Error::InvalidBasisPoints`] when fee or royalty limits are exceeded.
-pub fn set_config(env: &Env, config: Config) -> Result<(), Error> {
+/// Returns [`Error::InvalidBasisPoints`] when fee or royalty limits are exceeded,
+/// or [`Error::InvalidConfig`] when batch/collection size limits are violated.
+pub fn set_config(env: &Env, config: Config, updater: Address) -> Result<(), Error> {
     if config.platform_fee_bps > crate::platform_fee::MAX_PLATFORM_FEE_BPS {
         return Err(Error::InvalidBasisPoints);
     }
     if config.default_royalty_bps > crate::default_royalty::MAX_ROYALTY_BPS {
         return Err(Error::InvalidBasisPoints);
     }
+    if config.max_batch_mint_size < 1 || config.max_batch_mint_size > 100 {
+        return Err(Error::InvalidConfig);
+    }
+    if config.max_collection_size < 1 || config.max_collection_size > 100_000 {
+        return Err(Error::InvalidConfig);
+    }
+
+    let old = get_config(env);
+
+    // Emit events for changed u32 fields.
+    if let Some(ref old) = old {
+        emit_if_changed(env, &updater, "platform_fee_bps", old.platform_fee_bps, config.platform_fee_bps);
+        emit_if_changed(env, &updater, "default_royalty_bps", old.default_royalty_bps, config.default_royalty_bps);
+        emit_if_changed(env, &updater, "max_batch_mint_size", old.max_batch_mint_size, config.max_batch_mint_size);
+        emit_if_changed(env, &updater, "max_collection_size", old.max_collection_size, config.max_collection_size);
+    }
+
     env.storage().instance().set(&DataKey::Config, &config);
     Ok(())
+}
+
+fn emit_if_changed(env: &Env, updater: &Address, key: &str, old_value: u32, new_value: u32) {
+    if old_value != new_value {
+        env.events().publish(
+            ("config_update",),
+            ConfigUpdateEvent {
+                key: String::from_str(env, key),
+                old_value,
+                new_value,
+                updater: updater.clone(),
+            },
+        );
+    }
 }
 
 /// Return the stored [`Config`], or `None` if the contract is not yet initialized.
 pub fn get_config(env: &Env) -> Option<Config> {
     env.storage().instance().get(&DataKey::Config)
+}
+
+/// Reusable service for reading, validating, updating config and emitting events.
+pub struct ConfigService;
+
+impl ConfigService {
+    pub fn read_config(env: &Env) -> Option<Config> {
+        get_config(env)
+    }
+
+    pub fn validate_update(config: &Config) -> Result<(), Error> {
+        if config.platform_fee_bps > crate::platform_fee::MAX_PLATFORM_FEE_BPS {
+            return Err(Error::InvalidBasisPoints);
+        }
+        if config.default_royalty_bps > crate::default_royalty::MAX_ROYALTY_BPS {
+            return Err(Error::InvalidBasisPoints);
+        }
+        if config.max_batch_mint_size < 1 || config.max_batch_mint_size > 100 {
+            return Err(Error::InvalidConfig);
+        }
+        if config.max_collection_size < 1 || config.max_collection_size > 100_000 {
+            return Err(Error::InvalidConfig);
+        }
+        Ok(())
+    }
+
+    pub fn update_config(env: &Env, config: Config, updater: Address) -> Result<(), Error> {
+        Self::validate_update(&config)?;
+        set_config(env, config, updater)
+    }
 }

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -11,7 +11,7 @@ mod default_royalty;
 mod platform_fee;
 mod types;
 
-pub use config::{get_config, set_config, Config, CONTRACT_VERSION};
+pub use config::{get_config, set_config, Config, ConfigService, ConfigUpdateEvent, CONTRACT_VERSION, MAX_BATCH_MINT_SIZE, MAX_COLLECTION_SIZE};
 pub use default_royalty::{
     get_default_royalty_bps, set_default_royalty_bps, DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS,
 };
@@ -47,12 +47,76 @@ impl ClipCashNFT {
     pub fn set_config(env: Env, admin: Address, cfg: Config) -> Result<(), Error> {
         Self::require_admin(&env, &admin)?;
         admin.require_auth();
-        config::set_config(&env, cfg)
+        config::set_config(&env, cfg, admin)
     }
 
     /// Return the current [`Config`], or `None` before initialization.
     pub fn get_config(env: Env) -> Option<Config> {
         config::get_config(&env)
+    }
+
+    /// Return max batch mint size (defaults to MAX_BATCH_MINT_SIZE if config not set).
+    pub fn get_max_batch_mint_size(env: Env) -> u32 {
+        config::get_config(&env)
+            .map(|c| c.max_batch_mint_size)
+            .unwrap_or(MAX_BATCH_MINT_SIZE)
+    }
+
+    /// Set max batch mint size (1–100). Admin only.
+    pub fn set_max_batch_mint_size(env: Env, admin: Address, value: u32) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        if value < 1 || value > 100 {
+            return Err(Error::InvalidConfig);
+        }
+        let mut cfg = config::get_config(&env).ok_or(Error::NotInitialized)?;
+        let old = cfg.max_batch_mint_size;
+        cfg.max_batch_mint_size = value;
+        if old != value {
+            env.events().publish(
+                ("config_update",),
+                config::ConfigUpdateEvent {
+                    key: soroban_sdk::String::from_str(&env, "max_batch_mint_size"),
+                    old_value: old,
+                    new_value: value,
+                    updater: admin.clone(),
+                },
+            );
+        }
+        env.storage().instance().set(&DataKey::Config, &cfg);
+        Ok(())
+    }
+
+    /// Return max collection size (defaults to MAX_COLLECTION_SIZE if config not set).
+    pub fn get_max_collection_size(env: Env) -> u32 {
+        config::get_config(&env)
+            .map(|c| c.max_collection_size)
+            .unwrap_or(MAX_COLLECTION_SIZE)
+    }
+
+    /// Set max collection size (1–100 000). Admin only.
+    pub fn set_max_collection_size(env: Env, admin: Address, value: u32) -> Result<(), Error> {
+        Self::require_admin(&env, &admin)?;
+        admin.require_auth();
+        if value < 1 || value > 100_000 {
+            return Err(Error::InvalidConfig);
+        }
+        let mut cfg = config::get_config(&env).ok_or(Error::NotInitialized)?;
+        let old = cfg.max_collection_size;
+        cfg.max_collection_size = value;
+        if old != value {
+            env.events().publish(
+                ("config_update",),
+                config::ConfigUpdateEvent {
+                    key: soroban_sdk::String::from_str(&env, "max_collection_size"),
+                    old_value: old,
+                    new_value: value,
+                    updater: admin.clone(),
+                },
+            );
+        }
+        env.storage().instance().set(&DataKey::Config, &cfg);
+        Ok(())
     }
 
     // ─── Default Royalty ─────────────────────────────────────────────────────

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -61,4 +61,5 @@ pub enum Error {
     SignerNotSet = 8,
     InvalidSignature = 9,
     InvalidBasisPoints = 10,
+    InvalidConfig = 11,
 }


### PR DESCRIPTION
Closes #481
Closes #482
Closes #484
Closes #487

## Summary
- Added `max_batch_mint_size` and `max_collection_size` fields to `Config` with validation
- Added `ConfigUpdateEvent` emitted whenever a config value changes
- Added `ConfigService` struct providing a reusable read/update/validate/emit interface
- Wired getters and setters into the contract entry point