### PR TITLE
feat(storage): add migration helper, version storage, constants, and deserializer

### DIFF
--- a/clips_nft/src/config.rs
+++ b/clips_nft/src/config.rs
@@ -7,12 +7,7 @@ use soroban_sdk::{contracttype, Address, Env, String};
 
 use crate::types::{DataKey, Error};
 
-/// Contract version constant — bump on breaking interface changes.
-pub const CONTRACT_VERSION: u32 = 1;
-
-/// Default and limit constants for batch/collection size.
-pub const MAX_BATCH_MINT_SIZE: u32 = 50;
-pub const MAX_COLLECTION_SIZE: u32 = 10_000;
+pub use crate::storage_constants::{CONTRACT_VERSION, MAX_BATCH_MINT_SIZE, MAX_COLLECTION_SIZE};
 
 /// Reusable struct that holds every global contract setting.
 ///

--- a/clips_nft/src/config_validator.rs
+++ b/clips_nft/src/config_validator.rs
@@ -9,8 +9,7 @@ use crate::default_royalty::MAX_ROYALTY_BPS;
 use crate::platform_fee::MAX_PLATFORM_FEE_BPS;
 use crate::types::Error;
 
-/// Maximum collection size limit (prevents unbounded storage growth).
-pub const MAX_COLLECTION_LIMIT: u32 = 100_000;
+pub use crate::storage_constants::MAX_COLLECTION_LIMIT;
 
 /// Validate a platform fee value in basis points.
 ///

--- a/clips_nft/src/contract_version.rs
+++ b/clips_nft/src/contract_version.rs
@@ -1,0 +1,70 @@
+//! Contract version storage — persists migration version and upgrade timestamp.
+//!
+//! # Storage
+//! Key: `DataKey::ContractVersion` (instance storage)
+//!
+//! The stored [`ContractVersionRecord`] tracks which migration steps have been
+//! applied and when the contract was last upgraded.
+
+use soroban_sdk::{contracttype, Env};
+
+use crate::storage_constants::{
+    DEFAULT_UPGRADE_TIMESTAMP, INITIAL_MIGRATION_VERSION,
+};
+use crate::types::DataKey;
+
+/// Metadata persisted across contract upgrades.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractVersionRecord {
+    /// Highest migration step that has been successfully applied.
+    pub migration_version: u32,
+    /// Ledger timestamp of the most recent upgrade / migration.
+    pub upgrade_timestamp: u64,
+}
+
+impl ContractVersionRecord {
+    /// Default record for freshly deployed contracts (pre-migration).
+    pub fn initial() -> Self {
+        Self {
+            migration_version: INITIAL_MIGRATION_VERSION,
+            upgrade_timestamp: DEFAULT_UPGRADE_TIMESTAMP,
+        }
+    }
+}
+
+/// Load the stored version record, falling back to [`ContractVersionRecord::initial`].
+pub fn get_version_record(env: &Env) -> ContractVersionRecord {
+    env.storage()
+        .instance()
+        .get(&DataKey::ContractVersion)
+        .unwrap_or_else(ContractVersionRecord::initial)
+}
+
+/// Return the stored migration version (0 before any migration runs).
+pub fn get_migration_version(env: &Env) -> u32 {
+    get_version_record(env).migration_version
+}
+
+/// Return the ledger timestamp recorded at the last upgrade.
+pub fn get_upgrade_timestamp(env: &Env) -> u64 {
+    get_version_record(env).upgrade_timestamp
+}
+
+/// Persist a full version record.
+pub fn set_version_record(env: &Env, record: &ContractVersionRecord) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ContractVersion, record);
+}
+
+/// Record a successful migration step with the current ledger timestamp.
+pub fn record_upgrade(env: &Env, migration_version: u32, timestamp: u64) {
+    set_version_record(
+        env,
+        &ContractVersionRecord {
+            migration_version,
+            upgrade_timestamp: timestamp,
+        },
+    );
+}

--- a/clips_nft/src/default_royalty.rs
+++ b/clips_nft/src/default_royalty.rs
@@ -15,11 +15,7 @@ use soroban_sdk::Env;
 
 use crate::types::{DataKey, Error};
 
-/// Absolute maximum royalty: 100 % = 10 000 basis points.
-pub const MAX_ROYALTY_BPS: u32 = 10_000;
-
-/// Factory default applied when no custom value has been set (5 % = 500 bps).
-pub const DEFAULT_ROYALTY_BPS: u32 = 500;
+pub use crate::storage_constants::{DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS};
 
 /// Persist the default royalty in basis points.
 ///

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -10,27 +10,53 @@ mod blacklist;
 mod config;
 mod config_guard;
 mod config_validator;
+mod contract_version;
 mod default_royalty;
+mod migration;
+mod operator_approval;
+mod pause_state;
 mod payment_currency;
 mod platform_fee;
+mod storage_constants;
+mod storage_deserializer;
 mod token_approval;
+mod token_storage;
 mod types;
 
 pub use blacklist::{add_wallet, is_blacklisted, remove_wallet};
-pub use config::{get_config, set_config, Config, CONTRACT_VERSION};
-pub use default_royalty::{
-    get_default_royalty_bps, set_default_royalty_bps, DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS,
+pub use config::{get_config, set_config, Config};
+pub use contract_version::{
+    get_migration_version, get_upgrade_timestamp, get_version_record, record_upgrade,
+    set_version_record, ContractVersionRecord,
 };
+pub use migration::{is_fully_migrated, migrate_to_current, run_migrations, MigrationEvent};
+pub use storage_constants::{
+    BASIS_POINTS_SCALE, CONTRACT_VERSION, CURRENT_MIGRATION_VERSION,
+    DEFAULT_NEXT_TOKEN_ID, DEFAULT_PAUSED, DEFAULT_PLATFORM_FEE_BPS, DEFAULT_ROYALTY_BPS,
+    DEFAULT_TOTAL_SUPPLY, DEFAULT_UPGRADE_TIMESTAMP, INITIAL_MIGRATION_VERSION,
+    MAX_BATCH_MINT_SIZE, MAX_BATCH_MINT_SIZE_LIMIT, MAX_COLLECTION_LIMIT, MAX_COLLECTION_SIZE,
+    MAX_PLATFORM_FEE_BPS, MAX_ROYALTY_BPS, MIN_BATCH_MINT_SIZE, MIN_COLLECTION_SIZE,
+};
+pub use storage_deserializer::{
+    deserialize_metadata, deserialize_royalty, deserialize_token, read_instance,
+    read_persistent,
+};
+
+/// Compile-time contract version (alias used by upgrade/migration tests).
+pub const VERSION: u32 = CONTRACT_VERSION;
+pub use default_royalty::{get_default_royalty_bps, set_default_royalty_bps};
 pub use operator_approval::{is_operator, remove_operator, save_operator};
 pub use pause_state::{get_pause_state, save_pause_state};
-pub use platform_fee::{get_platform_fee, set_platform_fee, MAX_PLATFORM_FEE_BPS};
+pub use platform_fee::{get_platform_fee, set_platform_fee};
 pub use config_guard::require_config_admin;
 pub use config_validator::{
     validate_collection_limit, validate_config, validate_fee, validate_royalty_bps, validate_uri,
-    MAX_COLLECTION_LIMIT,
 };
 pub use payment_currency::{add_currency, get_currencies, is_supported, remove_currency};
-pub use types::{DataKey, Error, MintEvent, Royalty, RoyaltyInfo, TokenData, TokenId};
+pub use types::{
+    BurnEvent, DataKey, Error, MintEvent, Royalty, RoyaltyInfo, RoyaltyPaidEvent, TokenData,
+    TokenId, TransferEvent,
+};
 
 use soroban_sdk::{
     contract, contractimpl, BytesN, Env, String,
@@ -62,7 +88,7 @@ impl ClipCashNFT {
     pub fn set_config(env: Env, admin: Address, cfg: Config) -> Result<(), Error> {
         config_guard::require_config_admin(&env, &admin)?;
         config_validator::validate_config(&env, &cfg)?;
-        config::set_config(&env, cfg)
+        config::set_config(&env, cfg, admin)
     }
 
     /// Return the current [`Config`], or `None` before initialization.

--- a/clips_nft/src/migration.rs
+++ b/clips_nft/src/migration.rs
@@ -1,0 +1,89 @@
+//! Storage migration helper — versioned, idempotent migration runner.
+//!
+//! Migrations are applied sequentially from the stored migration version up to
+//! the requested target. Each step is safe to re-run: already-applied steps are
+//! skipped and individual step functions are idempotent.
+
+use soroban_sdk::{contracttype, Env};
+
+use crate::contract_version::{get_migration_version, record_upgrade};
+use crate::storage_constants::{CURRENT_MIGRATION_VERSION, event_keys};
+use crate::types::{DataKey, Error};
+
+/// A single migration step identified by its target version number.
+pub struct MigrationStep {
+    pub version: u32,
+    pub migrate: fn(&Env) -> Result<(), Error>,
+}
+
+/// Event emitted after each migration step completes.
+#[contracttype]
+#[derive(Clone)]
+pub struct MigrationEvent {
+    pub from_version: u32,
+    pub to_version: u32,
+    pub timestamp: u64,
+}
+
+/// Run all pending migrations up to `target_version`.
+///
+/// Returns the migration version after execution. Safe to call multiple times —
+/// already-applied steps are skipped.
+pub fn run_migrations(env: &Env, target_version: u32) -> Result<u32, Error> {
+    let current = get_migration_version(env);
+    if current >= target_version {
+        return Ok(current);
+    }
+
+    for step in migration_steps() {
+        if step.version <= current {
+            continue;
+        }
+        if step.version > target_version {
+            break;
+        }
+        (step.migrate)(env)?;
+        let ts = env.ledger().timestamp();
+        record_upgrade(env, step.version, ts);
+        env.events().publish(
+            (event_keys::MIGRATION,),
+            MigrationEvent {
+                from_version: step.version.saturating_sub(1),
+                to_version: step.version,
+                timestamp: ts,
+            },
+        );
+    }
+
+    Ok(get_migration_version(env))
+}
+
+/// Migrate to the current release's target migration version.
+pub fn migrate_to_current(env: &Env) -> Result<u32, Error> {
+    run_migrations(env, CURRENT_MIGRATION_VERSION)
+}
+
+/// Returns true when no further migrations are pending.
+pub fn is_fully_migrated(env: &Env) -> bool {
+    get_migration_version(env) >= CURRENT_MIGRATION_VERSION
+}
+
+fn migration_steps() -> &'static [MigrationStep] {
+    &[MigrationStep {
+        version: 1,
+        migrate: migrate_v0_to_v1,
+    }]
+}
+
+/// v0 → v1: seed `TotalSupply` from `NextTokenId` when the key is absent.
+fn migrate_v0_to_v1(env: &Env) -> Result<(), Error> {
+    if !env.storage().instance().has(&DataKey::TotalSupply) {
+        let next: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextTokenId)
+            .unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalSupply, &next);
+    }
+    Ok(())
+}

--- a/clips_nft/src/platform_fee.rs
+++ b/clips_nft/src/platform_fee.rs
@@ -13,8 +13,7 @@ use soroban_sdk::Env;
 
 use crate::types::{DataKey, Error};
 
-/// Maximum platform fee: 10 % = 1 000 basis points.
-pub const MAX_PLATFORM_FEE_BPS: u32 = 1_000;
+pub use crate::storage_constants::MAX_PLATFORM_FEE_BPS;
 
 /// Store the platform fee in basis points.
 ///

--- a/clips_nft/src/storage_constants.rs
+++ b/clips_nft/src/storage_constants.rs
@@ -1,0 +1,77 @@
+//! Centralized storage constants — key prefixes, limits, and defaults.
+//!
+//! All storage-related magic numbers and namespace identifiers live here so
+//! migration, deserialization, and domain modules share a single source of truth.
+
+// ─── Contract / migration version ───────────────────────────────────────────
+
+/// Compile-time contract interface version (bump on breaking ABI changes).
+pub const CONTRACT_VERSION: u32 = 1;
+
+/// Migration version before any upgrade has run (legacy deployments).
+pub const INITIAL_MIGRATION_VERSION: u32 = 0;
+
+/// Target migration version for the current contract release.
+pub const CURRENT_MIGRATION_VERSION: u32 = 1;
+
+// ─── Basis points scale ─────────────────────────────────────────────────────
+
+pub const BASIS_POINTS_SCALE: u32 = 10_000;
+
+// ─── Limits ───────────────────────────────────────────────────────────────────
+
+pub const MAX_ROYALTY_BPS: u32 = 10_000;
+pub const MAX_PLATFORM_FEE_BPS: u32 = 1_000;
+pub const MAX_BATCH_MINT_SIZE: u32 = 50;
+pub const MAX_COLLECTION_SIZE: u32 = 10_000;
+pub const MAX_COLLECTION_LIMIT: u32 = 100_000;
+pub const MIN_BATCH_MINT_SIZE: u32 = 1;
+pub const MAX_BATCH_MINT_SIZE_LIMIT: u32 = 100;
+pub const MIN_COLLECTION_SIZE: u32 = 1;
+
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
+pub const DEFAULT_ROYALTY_BPS: u32 = 500;
+pub const DEFAULT_PLATFORM_FEE_BPS: u32 = 0;
+pub const DEFAULT_PAUSED: bool = false;
+pub const DEFAULT_NEXT_TOKEN_ID: u32 = 0;
+pub const DEFAULT_TOTAL_SUPPLY: u32 = 0;
+pub const DEFAULT_UPGRADE_TIMESTAMP: u64 = 0;
+
+// ─── Storage key namespace prefixes ───────────────────────────────────────────
+
+/// Logical prefixes for instance-scoped (contract-global) storage keys.
+pub mod instance_prefix {
+    pub const ADMIN: &str = "admin";
+    pub const CONFIG: &str = "config";
+    pub const VERSION: &str = "version";
+    pub const PAUSED: &str = "paused";
+    pub const SIGNER: &str = "signer";
+    pub const SUPPLY: &str = "supply";
+    pub const FEE: &str = "fee";
+    pub const ROYALTY: &str = "royalty";
+}
+
+/// Logical prefixes for persistent (per-token / per-address) storage keys.
+pub mod persistent_prefix {
+    pub const TOKEN: &str = "token";
+    pub const METADATA: &str = "metadata";
+    pub const ROYALTY: &str = "royalty";
+    pub const CLIP: &str = "clip";
+    pub const APPROVAL: &str = "approval";
+    pub const OPERATOR: &str = "operator";
+    pub const BLACKLIST: &str = "blacklist";
+}
+
+// ─── Event key prefixes ───────────────────────────────────────────────────────
+
+pub mod event_keys {
+    pub const CONFIG_UPDATE: &str = "config_update";
+    pub const MINT: &str = "mint";
+    pub const TRANSFER: &str = "transfer";
+    pub const BURN: &str = "burn";
+    pub const ROYALTY_PAID: &str = "royalty_paid";
+    pub const PAUSED: &str = "paused";
+    pub const UNPAUSED: &str = "unpaused";
+    pub const MIGRATION: &str = "migration";
+}

--- a/clips_nft/src/storage_deserializer.rs
+++ b/clips_nft/src/storage_deserializer.rs
@@ -1,0 +1,60 @@
+//! Storage deserializer — safe typed reads with corruption handling.
+//!
+//! Wraps Soroban storage reads with validation so callers receive well-formed
+//! records or a deterministic [`Error::CorruptedStorage`] instead of panicking.
+
+use soroban_sdk::{Env, String, Val};
+
+use crate::storage_constants::MAX_ROYALTY_BPS;
+use crate::types::{DataKey, Error, Royalty, TokenData, TokenId};
+
+/// Read an instance-scoped value. Returns `None` when the key is absent.
+pub fn read_instance<T>(env: &Env, key: &DataKey) -> Option<T>
+where
+    T: soroban_sdk::TryFromVal<Env, Val> + soroban_sdk::IntoVal<Env, Val>,
+{
+    env.storage().instance().get(key)
+}
+
+/// Read a persistent value. Returns `None` when the key is absent.
+pub fn read_persistent<T>(env: &Env, key: &DataKey) -> Option<T>
+where
+    T: soroban_sdk::TryFromVal<Env, Val> + soroban_sdk::IntoVal<Env, Val>,
+{
+    env.storage().persistent().get(key)
+}
+
+/// Deserialize and validate token data for `token_id`.
+pub fn deserialize_token(env: &Env, token_id: TokenId) -> Result<TokenData, Error> {
+    let data: TokenData = read_persistent(env, &DataKey::Token(token_id))
+        .ok_or(Error::TokenNotFound)?;
+    validate_token_data(&data)
+}
+
+/// Deserialize and validate a metadata URI for `token_id`.
+pub fn deserialize_metadata(env: &Env, token_id: TokenId) -> Result<String, Error> {
+    let uri: String = read_persistent(env, &DataKey::Metadata(token_id))
+        .ok_or(Error::TokenNotFound)?;
+    if uri.len() == 0 {
+        return Err(Error::CorruptedStorage);
+    }
+    Ok(uri)
+}
+
+/// Deserialize and validate royalty config for `token_id`.
+pub fn deserialize_royalty(env: &Env, token_id: TokenId) -> Result<Royalty, Error> {
+    let royalty: Royalty = read_persistent(env, &DataKey::Royalty(token_id))
+        .ok_or(Error::TokenNotFound)?;
+    validate_royalty(&royalty)
+}
+
+fn validate_token_data(data: &TokenData) -> Result<TokenData, Error> {
+    Ok(data.clone())
+}
+
+fn validate_royalty(royalty: &Royalty) -> Result<Royalty, Error> {
+    if royalty.basis_points > MAX_ROYALTY_BPS {
+        return Err(Error::CorruptedStorage);
+    }
+    Ok(royalty.clone())
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -42,9 +42,28 @@ pub struct BurnEvent {
 }
 
 #[contracttype]
+#[derive(Clone)]
+pub struct TransferEvent {
+    pub from: Address,
+    pub to: Address,
+    pub token_id: TokenId,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RoyaltyPaidEvent {
+    pub token_id: TokenId,
+    pub payer: Address,
+    pub receiver: Address,
+    pub amount: i128,
+    pub asset_address: Option<Address>,
+}
+
+#[contracttype]
 pub enum DataKey {
     Admin,
     NextTokenId,
+    TotalSupply,
     Paused,
     Signer,
     Token(u32),
@@ -56,6 +75,22 @@ pub enum DataKey {
     Config,
     /// List of supported payment currency addresses.
     SupportedCurrencies,
+    /// Migration version and upgrade timestamp metadata.
+    ContractVersion,
+    /// Per-token approval address.
+    Approval(u32),
+    /// Operator approval for all tokens of an owner.
+    OperatorApproval(Address, Address),
+    /// Wallet blacklist flag.
+    Blacklisted(Address),
+    /// Accumulated platform revenue.
+    PlatformRevenue,
+    /// Per-collection supply counter.
+    CollectionSupply(u32),
+    /// Royalty payment history per token.
+    RoyaltyHistory(u32),
+    /// Separate royalty recipient lookup.
+    RoyaltyRecipient(u32),
 }
 
 #[contracterror]
@@ -87,4 +122,8 @@ pub enum Error {
     DuplicateCurrency = 16,
     /// Currency not found in the supported list.
     CurrencyNotFound = 17,
+    /// Configuration value is outside the allowed range.
+    InvalidConfig = 18,
+    /// Stored data failed validation or is malformed.
+    CorruptedStorage = 19,
 }

--- a/clips_nft/tests/storage_modules.rs
+++ b/clips_nft/tests/storage_modules.rs
@@ -1,0 +1,182 @@
+//! Integration tests for storage infrastructure modules.
+
+#![cfg(test)]
+
+use clips_nft::{
+    deserialize_metadata, deserialize_royalty, deserialize_token, get_migration_version,
+    get_upgrade_timestamp, is_fully_migrated, migrate_to_current, record_upgrade, run_migrations,
+    ClipCashNFT, ClipCashNFTClient, DataKey, Error, Royalty, TokenData, CONTRACT_VERSION,
+    CURRENT_MIGRATION_VERSION, DEFAULT_ROYALTY_BPS, INITIAL_MIGRATION_VERSION, MAX_ROYALTY_BPS,
+    VERSION,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String,
+};
+
+struct TestCtx {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+}
+
+fn setup() -> TestCtx {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ClipCashNFT, ());
+    let client = ClipCashNFTClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    TestCtx {
+        env,
+        contract_id,
+        admin,
+    }
+}
+
+fn with_contract<F, R>(ctx: &TestCtx, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    ctx.env.as_contract(&ctx.contract_id, f)
+}
+
+#[test]
+fn test_version_record_defaults_before_migration() {
+    let ctx = setup();
+    with_contract(&ctx, || {
+        assert_eq!(get_migration_version(&ctx.env), INITIAL_MIGRATION_VERSION);
+        assert_eq!(get_upgrade_timestamp(&ctx.env), 0);
+    });
+}
+
+#[test]
+fn test_record_upgrade_persists_version_and_timestamp() {
+    let ctx = setup();
+    ctx.env.ledger().set_timestamp(1_700_000_000);
+    with_contract(&ctx, || {
+        record_upgrade(&ctx.env, 1, ctx.env.ledger().timestamp());
+        assert_eq!(get_migration_version(&ctx.env), 1);
+        assert_eq!(get_upgrade_timestamp(&ctx.env), 1_700_000_000);
+    });
+}
+
+#[test]
+fn test_migrate_to_current_is_idempotent() {
+    let ctx = setup();
+    ctx.env.ledger().set_timestamp(100);
+
+    with_contract(&ctx, || {
+        let v1 = migrate_to_current(&ctx.env).expect("first migrate");
+        assert_eq!(v1, CURRENT_MIGRATION_VERSION);
+        assert!(is_fully_migrated(&ctx.env));
+
+        let v2 = migrate_to_current(&ctx.env).expect("second migrate");
+        assert_eq!(v2, CURRENT_MIGRATION_VERSION);
+        assert_eq!(get_migration_version(&ctx.env), CURRENT_MIGRATION_VERSION);
+    });
+}
+
+#[test]
+fn test_migrate_seeds_total_supply_from_next_token_id() {
+    let ctx = setup();
+    with_contract(&ctx, || {
+        ctx.env
+            .storage()
+            .instance()
+            .set(&DataKey::NextTokenId, &5u32);
+        ctx.env.storage().instance().remove(&DataKey::TotalSupply);
+
+        run_migrations(&ctx.env, CURRENT_MIGRATION_VERSION).expect("migrate");
+
+        let total: u32 = ctx
+            .env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .expect("TotalSupply seeded");
+        assert_eq!(total, 5);
+    });
+}
+
+#[test]
+fn test_deserialize_token_roundtrip() {
+    let ctx = setup();
+    with_contract(&ctx, || {
+        let owner = Address::generate(&ctx.env);
+        let data = TokenData {
+            owner: owner.clone(),
+            clip_id: 42,
+        };
+        ctx.env
+            .storage()
+            .persistent()
+            .set(&DataKey::Token(1), &data);
+
+        let loaded = deserialize_token(&ctx.env, 1).expect("valid token");
+        assert_eq!(loaded.owner, owner);
+        assert_eq!(loaded.clip_id, 42);
+    });
+}
+
+#[test]
+fn test_deserialize_metadata_rejects_empty_uri() {
+    let ctx = setup();
+    with_contract(&ctx, || {
+        let empty = String::from_str(&ctx.env, "");
+        ctx.env
+            .storage()
+            .persistent()
+            .set(&DataKey::Metadata(1), &empty);
+
+        assert_eq!(
+            deserialize_metadata(&ctx.env, 1),
+            Err(Error::CorruptedStorage)
+        );
+    });
+}
+
+#[test]
+fn test_deserialize_royalty_rejects_invalid_bps() {
+    let ctx = setup();
+    with_contract(&ctx, || {
+        let royalty = Royalty {
+            recipient: Address::generate(&ctx.env),
+            basis_points: MAX_ROYALTY_BPS + 1,
+            asset_address: None,
+        };
+        ctx.env
+            .storage()
+            .persistent()
+            .set(&DataKey::Royalty(1), &royalty);
+
+        assert!(matches!(
+            deserialize_royalty(&ctx.env, 1),
+            Err(Error::CorruptedStorage)
+        ));
+    });
+}
+
+#[test]
+fn test_deserialize_royalty_accepts_valid_bps() {
+    let ctx = setup();
+    with_contract(&ctx, || {
+        let royalty = Royalty {
+            recipient: Address::generate(&ctx.env),
+            basis_points: DEFAULT_ROYALTY_BPS,
+            asset_address: None,
+        };
+        ctx.env
+            .storage()
+            .persistent()
+            .set(&DataKey::Royalty(1), &royalty);
+
+        let loaded = deserialize_royalty(&ctx.env, 1).expect("valid royalty");
+        assert_eq!(loaded.basis_points, DEFAULT_ROYALTY_BPS);
+    });
+}
+
+#[test]
+fn test_version_constant_matches_storage_constants() {
+    assert_eq!(VERSION, CONTRACT_VERSION);
+}


### PR DESCRIPTION
PR description
Summary
This PR adds the foundational storage infrastructure for contract upgrades in clips_nft. Four new modules centralize constants, track migration state, run versioned migrations safely, and deserialize stored records with validation.

Changes
Task 1 — Storage Migration Helper (migration.rs)
run_migrations(env, target_version) — applies pending steps sequentially, skips already-applied versions (idempotent)
migrate_to_current(env) — migrates to CURRENT_MIGRATION_VERSION
is_fully_migrated(env) — checks whether migration is complete
v0 → v1 migration: seeds DataKey::TotalSupply from NextTokenId when absent (legacy deployments)
Emits MigrationEvent on each completed step

Task 2 — Contract Version Storage (contract_version.rs)
ContractVersionRecord stored under DataKey::ContractVersion (instance storage)
Tracks migration version and upgrade timestamp
API: get_migration_version, get_upgrade_timestamp, record_upgrade, set_version_record

Task 3 — Storage Constants (storage_constants.rs)
Limits: MAX_ROYALTY_BPS, MAX_PLATFORM_FEE_BPS, MAX_BATCH_MINT_SIZE, MAX_COLLECTION_SIZE, etc.
Defaults: DEFAULT_ROYALTY_BPS, DEFAULT_PLATFORM_FEE_BPS, DEFAULT_PAUSED, etc.
Key prefixes: instance_prefix::*, persistent_prefix::*, event_keys::*
Domain modules (config, default_royalty, platform_fee, config_validator) now re-export from this single source

Task 4 — Storage Deserializer (storage_deserializer.rs)
deserialize_token, deserialize_metadata, deserialize_royalty — typed reads with validation
read_instance / read_persistent — generic safe readers
Returns Error::CorruptedStorage for invalid data (empty URI, royalty bps > 10_000)

closes #529 
closes #531 
closes #535 
closes #538