### PR TITLE
feat: add creator, token URI, frozen token, and wallet index storage

### DIFF
--- a/clips_nft/src/creator_storage.rs
+++ b/clips_nft/src/creator_storage.rs
@@ -1,0 +1,25 @@
+//! Creator storage — records the creator wallet for every NFT.
+//!
+//! # Storage
+//! Key: `DataKey::Creator(token_id)` (persistent storage)
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, Error, TokenId};
+
+/// Save the creator wallet for a token.
+pub fn set_creator(env: &Env, token_id: TokenId, creator: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Creator(token_id), creator);
+}
+
+/// Read the creator wallet for a token.
+///
+/// Returns `Err(TokenNotFound)` if no creator has been recorded.
+pub fn get_creator(env: &Env, token_id: TokenId) -> Result<Address, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Creator(token_id))
+        .ok_or(Error::TokenNotFound)
+}

--- a/clips_nft/src/frozen_token.rs
+++ b/clips_nft/src/frozen_token.rs
@@ -1,0 +1,30 @@
+//! Frozen token storage — tracks which NFTs are frozen.
+//!
+//! # Storage
+//! Key: `DataKey::FrozenToken(token_id)` (persistent storage)
+
+use soroban_sdk::Env;
+
+use crate::types::{DataKey, TokenId};
+
+/// Mark a token as frozen.
+pub fn freeze_token(env: &Env, token_id: TokenId) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::FrozenToken(token_id), &true);
+}
+
+/// Unfreeze a token.
+pub fn unfreeze_token(env: &Env, token_id: TokenId) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::FrozenToken(token_id));
+}
+
+/// Return `true` if the token is currently frozen.
+pub fn is_frozen(env: &Env, token_id: TokenId) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FrozenToken(token_id))
+        .unwrap_or(false)
+}

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -10,13 +10,21 @@ mod blacklist;
 mod config;
 mod config_guard;
 mod config_validator;
+mod creator_storage;
 mod default_royalty;
+mod frozen_token;
 mod payment_currency;
 mod platform_fee;
 mod token_approval;
+mod token_uri_storage;
 mod types;
+mod wallet_token_index;
 
 pub use blacklist::{add_wallet, is_blacklisted, remove_wallet};
+pub use creator_storage::{get_creator, set_creator};
+pub use frozen_token::{freeze_token, is_frozen, unfreeze_token};
+pub use token_uri_storage::{get_token_uri, set_token_uri};
+pub use wallet_token_index::{add_token_to_wallet, get_wallet_tokens, remove_token_from_wallet};
 pub use config::{get_config, set_config, Config, CONTRACT_VERSION};
 pub use default_royalty::{
     get_default_royalty_bps, set_default_royalty_bps, DEFAULT_ROYALTY_BPS, MAX_ROYALTY_BPS,

--- a/clips_nft/src/token_uri_storage.rs
+++ b/clips_nft/src/token_uri_storage.rs
@@ -1,0 +1,37 @@
+//! Token URI storage — saves and retrieves validated metadata URIs for every NFT.
+//!
+//! # Storage
+//! Key: `DataKey::TokenUri(token_id)` (persistent storage)
+
+use soroban_sdk::{Env, String};
+
+use crate::types::{DataKey, Error, TokenId};
+
+/// Validate a metadata URI — rejects empty strings.
+pub fn validate_uri(uri: &String) -> Result<(), Error> {
+    if uri.len() == 0 {
+        return Err(Error::InvalidURI);
+    }
+    Ok(())
+}
+
+/// Save a metadata URI for a token.
+///
+/// Validates the URI before persisting. Returns `Err(InvalidURI)` for an empty string.
+pub fn set_token_uri(env: &Env, token_id: TokenId, uri: &String) -> Result<(), Error> {
+    validate_uri(uri)?;
+    env.storage()
+        .persistent()
+        .set(&DataKey::TokenUri(token_id), uri);
+    Ok(())
+}
+
+/// Read the metadata URI for a token.
+///
+/// Returns `Err(TokenNotFound)` if no URI has been stored.
+pub fn get_token_uri(env: &Env, token_id: TokenId) -> Result<String, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TokenUri(token_id))
+        .ok_or(Error::TokenNotFound)
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -56,6 +56,14 @@ pub enum DataKey {
     Config,
     /// List of supported payment currency addresses.
     SupportedCurrencies,
+    /// Creator wallet address for a token (#510).
+    Creator(u32),
+    /// Metadata URI stored via dedicated token URI storage (#507).
+    TokenUri(u32),
+    /// Frozen status for a token (#520).
+    FrozenToken(u32),
+    /// Token ownership index for a wallet (#516).
+    WalletTokens(Address),
 }
 
 #[contracterror]

--- a/clips_nft/src/wallet_token_index.rs
+++ b/clips_nft/src/wallet_token_index.rs
@@ -1,0 +1,39 @@
+//! Wallet token index — maintains a token ownership index for every wallet.
+//!
+//! # Storage
+//! Key: `DataKey::WalletTokens(wallet)` → `Vec<TokenId>` (persistent storage)
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{DataKey, TokenId};
+
+/// Add a token to a wallet's ownership index.
+pub fn add_token_to_wallet(env: &Env, wallet: &Address, token_id: TokenId) {
+    let mut tokens = get_wallet_tokens(env, wallet);
+    tokens.push_back(token_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::WalletTokens(wallet.clone()), &tokens);
+}
+
+/// Remove a token from a wallet's ownership index.
+pub fn remove_token_from_wallet(env: &Env, wallet: &Address, token_id: TokenId) {
+    let tokens = get_wallet_tokens(env, wallet);
+    let mut updated: Vec<TokenId> = Vec::new(env);
+    for t in tokens.iter() {
+        if t != token_id {
+            updated.push_back(t);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::WalletTokens(wallet.clone()), &updated);
+}
+
+/// Retrieve all token IDs owned by a wallet. Returns an empty vec if none recorded.
+pub fn get_wallet_tokens(env: &Env, wallet: &Address) -> Vec<TokenId> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::WalletTokens(wallet.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}


### PR DESCRIPTION
Closes #516
Closes #520 
Closes #507 
Closes #510 

---

## Summary
- **#510** — `creator_storage.rs`: save/read NFT creator wallet per token
- **#507** — `token_uri_storage.rs`: save/read/validate metadata URI per token
- **#520** — `frozen_token.rs`: freeze, unfreeze, and check frozen status per token
- **#516** — `wallet_token_index.rs`: add/remove/retrieve token ownership index per wallet

Adds 4 new `DataKey` variants (`Creator`, `TokenUri`, `FrozenToken`, `WalletTokens`) to `types.rs` and registers all modules in `lib.rs`.

## Test plan
- [ ] Verify `set_creator` / `get_creator` round-trips correctly
- [ ] Verify `set_token_uri` rejects empty strings and stores valid URIs
- [ ] Verify `freeze_token` / `unfreeze_token` / `is_frozen` transitions
- [ ] Verify `add_token_to_wallet` / `remove_token_from_wallet` / `get_wallet_tokens` index stays consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)