### PR TITLE
feat(minting): royalty %, creator/owner portfolio & collection storage (#673–#676)

### DIFF
--- a/clips_nft/src/creator_portfolio.rs
+++ b/clips_nft/src/creator_portfolio.rs
@@ -1,0 +1,126 @@
+//! Creator portfolio index (issue #674).
+//!
+//! Maintains an index of the NFTs created by each creator so a creator's full
+//! portfolio can be queried on-chain. The index preserves insertion order and
+//! rejects duplicate registrations.
+//!
+//! # Storage
+//! Key: `DataKey::CreatorTokens(creator)` → `Vec<TokenId>` (persistent storage)
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{DataKey, Error, TokenId};
+
+/// Return `true` if `token_id` is already indexed for `creator`.
+pub fn creator_contains_token(env: &Env, creator: &Address, token_id: TokenId) -> bool {
+    get_creator_portfolio(env, creator)
+        .iter()
+        .any(|t| t == token_id)
+}
+
+/// Add `token_id` to `creator`'s portfolio index.
+///
+/// # Errors
+/// Returns [`Error::DuplicateRecord`] if the token is already indexed for this creator.
+pub fn add_token_to_creator(
+    env: &Env,
+    creator: &Address,
+    token_id: TokenId,
+) -> Result<(), Error> {
+    if creator_contains_token(env, creator, token_id) {
+        return Err(Error::DuplicateRecord);
+    }
+    let mut tokens = get_creator_portfolio(env, creator);
+    tokens.push_back(token_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CreatorTokens(creator.clone()), &tokens);
+    Ok(())
+}
+
+/// Retrieve every token ID created by `creator`. Returns an empty vec if none recorded.
+pub fn get_creator_portfolio(env: &Env, creator: &Address) -> Vec<TokenId> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreatorTokens(creator.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AtomicMintContract;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn with_contract<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Env) -> R,
+    {
+        let env = Env::default();
+        let contract_id = env.register(AtomicMintContract, ());
+        env.as_contract(&contract_id, || f(&env))
+    }
+
+    #[test]
+    fn adds_token_to_creator_portfolio() {
+        with_contract(|env| {
+            let creator = Address::generate(env);
+            add_token_to_creator(env, &creator, 1).unwrap();
+            let portfolio = get_creator_portfolio(env, &creator);
+            assert_eq!(portfolio.len(), 1);
+            assert_eq!(portfolio.get(0).unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn supports_multiple_nfts_per_creator() {
+        with_contract(|env| {
+            let creator = Address::generate(env);
+            add_token_to_creator(env, &creator, 10).unwrap();
+            add_token_to_creator(env, &creator, 20).unwrap();
+            add_token_to_creator(env, &creator, 30).unwrap();
+
+            let portfolio = get_creator_portfolio(env, &creator);
+            assert_eq!(portfolio.len(), 3);
+            assert_eq!(portfolio.get(0).unwrap(), 10);
+            assert_eq!(portfolio.get(1).unwrap(), 20);
+            assert_eq!(portfolio.get(2).unwrap(), 30);
+        });
+    }
+
+    #[test]
+    fn prevents_duplicate_entries() {
+        with_contract(|env| {
+            let creator = Address::generate(env);
+            add_token_to_creator(env, &creator, 5).unwrap();
+            assert_eq!(
+                add_token_to_creator(env, &creator, 5),
+                Err(Error::DuplicateRecord)
+            );
+            assert_eq!(get_creator_portfolio(env, &creator).len(), 1);
+        });
+    }
+
+    #[test]
+    fn portfolios_are_isolated_per_creator() {
+        with_contract(|env| {
+            let alice = Address::generate(env);
+            let bob = Address::generate(env);
+            add_token_to_creator(env, &alice, 1).unwrap();
+            add_token_to_creator(env, &bob, 2).unwrap();
+
+            assert_eq!(get_creator_portfolio(env, &alice).len(), 1);
+            assert_eq!(get_creator_portfolio(env, &bob).len(), 1);
+            assert!(creator_contains_token(env, &alice, 1));
+            assert!(!creator_contains_token(env, &alice, 2));
+        });
+    }
+
+    #[test]
+    fn empty_portfolio_for_unknown_creator() {
+        with_contract(|env| {
+            let creator = Address::generate(env);
+            assert_eq!(get_creator_portfolio(env, &creator).len(), 0);
+        });
+    }
+}

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -52,6 +52,12 @@ pub mod storage_deserializer;
 pub use storage_deserializer::{deserialize_metadata, deserialize_royalty, deserialize_token};
 pub mod storage;
 
+// ─── Minting storage tasks (issues #673–#676) ─────────────────────────────────
+pub mod royalty_percentage;
+pub mod creator_portfolio;
+pub mod owner_portfolio;
+pub mod nft_collection;
+
 // ─── Guard / safety ───────────────────────────────────────────────────────────
 pub mod pause_guard;
 pub mod pause_state;

--- a/clips_nft/src/nft_collection.rs
+++ b/clips_nft/src/nft_collection.rs
@@ -1,0 +1,168 @@
+//! NFT ↔ collection association (issue #676).
+//!
+//! Registers newly minted NFTs under a ClipCash NFT collection. A collection
+//! must be registered before tokens can be associated with it; each association
+//! saves a token → collection reference and adds the token to the collection's
+//! membership list.
+//!
+//! # Storage
+//! - `DataKey::CollectionRegistered(collection_id)` → `bool` (existence marker)
+//! - `DataKey::TokenCollection(token_id)` → `u32` (collection reference)
+//! - `DataKey::CollectionMembers(collection_id)` → `Vec<TokenId>` (membership)
+//!
+//! All keys use persistent storage.
+
+use soroban_sdk::{Env, Vec};
+
+use crate::types::{DataKey, Error, TokenId};
+
+/// Register a collection so tokens can be associated with it. Idempotent.
+pub fn register_collection(env: &Env, collection_id: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CollectionRegistered(collection_id), &true);
+}
+
+/// Return `true` if `collection_id` has been registered.
+pub fn collection_exists(env: &Env, collection_id: u32) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CollectionRegistered(collection_id))
+        .unwrap_or(false)
+}
+
+/// Return `true` if `token_id` is already a member of `collection_id`.
+pub fn collection_contains_token(env: &Env, collection_id: u32, token_id: TokenId) -> bool {
+    get_collection_members(env, collection_id)
+        .iter()
+        .any(|t| t == token_id)
+}
+
+/// Associate `token_id` with `collection_id`.
+///
+/// Saves the token → collection reference and appends the token to the
+/// collection's membership list.
+///
+/// # Errors
+/// - [`Error::CollectionNotFound`] if the collection has not been registered.
+/// - [`Error::DuplicateRecord`] if the token is already a member.
+pub fn associate_nft(env: &Env, token_id: TokenId, collection_id: u32) -> Result<(), Error> {
+    if !collection_exists(env, collection_id) {
+        return Err(Error::CollectionNotFound);
+    }
+    if collection_contains_token(env, collection_id, token_id) {
+        return Err(Error::DuplicateRecord);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::TokenCollection(token_id), &collection_id);
+
+    let mut members = get_collection_members(env, collection_id);
+    members.push_back(token_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CollectionMembers(collection_id), &members);
+
+    Ok(())
+}
+
+/// Return the collection a token belongs to.
+///
+/// # Errors
+/// Returns [`Error::TokenNotFound`] if the token is not associated with any collection.
+pub fn get_nft_collection(env: &Env, token_id: TokenId) -> Result<u32, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TokenCollection(token_id))
+        .ok_or(Error::TokenNotFound)
+}
+
+/// Retrieve every token ID that belongs to `collection_id`. Empty if none recorded.
+pub fn get_collection_members(env: &Env, collection_id: u32) -> Vec<TokenId> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CollectionMembers(collection_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AtomicMintContract;
+    use soroban_sdk::Env;
+
+    fn with_contract<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Env) -> R,
+    {
+        let env = Env::default();
+        let contract_id = env.register(AtomicMintContract, ());
+        env.as_contract(&contract_id, || f(&env))
+    }
+
+    #[test]
+    fn register_and_check_collection() {
+        with_contract(|env| {
+            assert!(!collection_exists(env, 1));
+            register_collection(env, 1);
+            assert!(collection_exists(env, 1));
+        });
+    }
+
+    #[test]
+    fn associates_nft_with_registered_collection() {
+        with_contract(|env| {
+            register_collection(env, 1);
+            associate_nft(env, 100, 1).unwrap();
+
+            assert_eq!(get_nft_collection(env, 100).unwrap(), 1);
+            let members = get_collection_members(env, 1);
+            assert_eq!(members.len(), 1);
+            assert_eq!(members.get(0).unwrap(), 100);
+            assert!(collection_contains_token(env, 1, 100));
+        });
+    }
+
+    #[test]
+    fn rejects_association_with_unregistered_collection() {
+        with_contract(|env| {
+            assert_eq!(
+                associate_nft(env, 100, 42),
+                Err(Error::CollectionNotFound)
+            );
+        });
+    }
+
+    #[test]
+    fn prevents_duplicate_membership() {
+        with_contract(|env| {
+            register_collection(env, 1);
+            associate_nft(env, 100, 1).unwrap();
+            assert_eq!(associate_nft(env, 100, 1), Err(Error::DuplicateRecord));
+            assert_eq!(get_collection_members(env, 1).len(), 1);
+        });
+    }
+
+    #[test]
+    fn tracks_multiple_members_in_order() {
+        with_contract(|env| {
+            register_collection(env, 1);
+            associate_nft(env, 10, 1).unwrap();
+            associate_nft(env, 20, 1).unwrap();
+            associate_nft(env, 30, 1).unwrap();
+
+            let members = get_collection_members(env, 1);
+            assert_eq!(members.len(), 3);
+            assert_eq!(members.get(0).unwrap(), 10);
+            assert_eq!(members.get(2).unwrap(), 30);
+        });
+    }
+
+    #[test]
+    fn unknown_token_has_no_collection() {
+        with_contract(|env| {
+            assert_eq!(get_nft_collection(env, 999), Err(Error::TokenNotFound));
+        });
+    }
+}

--- a/clips_nft/src/owner_portfolio.rs
+++ b/clips_nft/src/owner_portfolio.rs
@@ -1,0 +1,118 @@
+//! Owner portfolio index (issue #675).
+//!
+//! Updates the owner's NFT portfolio after a successful mint. Tokens are stored
+//! in insertion order (ordering is preserved) and duplicate entries are rejected.
+//!
+//! # Storage
+//! Key: `DataKey::OwnerTokens(owner)` → `Vec<TokenId>` (persistent storage)
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{DataKey, Error, TokenId};
+
+/// Return `true` if `token_id` is already indexed for `owner`.
+pub fn owner_contains_token(env: &Env, owner: &Address, token_id: TokenId) -> bool {
+    get_owner_portfolio(env, owner).iter().any(|t| t == token_id)
+}
+
+/// Add `token_id` to `owner`'s portfolio index, appended at the end to preserve order.
+///
+/// # Errors
+/// Returns [`Error::DuplicateRecord`] if the token is already indexed for this owner.
+pub fn add_token_to_owner(env: &Env, owner: &Address, token_id: TokenId) -> Result<(), Error> {
+    if owner_contains_token(env, owner, token_id) {
+        return Err(Error::DuplicateRecord);
+    }
+    let mut tokens = get_owner_portfolio(env, owner);
+    tokens.push_back(token_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::OwnerTokens(owner.clone()), &tokens);
+    Ok(())
+}
+
+/// Retrieve every token ID owned by `owner`, in insertion order. Empty if none recorded.
+pub fn get_owner_portfolio(env: &Env, owner: &Address) -> Vec<TokenId> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::OwnerTokens(owner.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AtomicMintContract;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn with_contract<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Env) -> R,
+    {
+        let env = Env::default();
+        let contract_id = env.register(AtomicMintContract, ());
+        env.as_contract(&contract_id, || f(&env))
+    }
+
+    #[test]
+    fn adds_token_to_owner_portfolio() {
+        with_contract(|env| {
+            let owner = Address::generate(env);
+            add_token_to_owner(env, &owner, 1).unwrap();
+            let portfolio = get_owner_portfolio(env, &owner);
+            assert_eq!(portfolio.len(), 1);
+            assert_eq!(portfolio.get(0).unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn preserves_insertion_order() {
+        with_contract(|env| {
+            let owner = Address::generate(env);
+            add_token_to_owner(env, &owner, 30).unwrap();
+            add_token_to_owner(env, &owner, 10).unwrap();
+            add_token_to_owner(env, &owner, 20).unwrap();
+
+            let portfolio = get_owner_portfolio(env, &owner);
+            assert_eq!(portfolio.len(), 3);
+            assert_eq!(portfolio.get(0).unwrap(), 30);
+            assert_eq!(portfolio.get(1).unwrap(), 10);
+            assert_eq!(portfolio.get(2).unwrap(), 20);
+        });
+    }
+
+    #[test]
+    fn prevents_duplicate_entries() {
+        with_contract(|env| {
+            let owner = Address::generate(env);
+            add_token_to_owner(env, &owner, 7).unwrap();
+            assert_eq!(
+                add_token_to_owner(env, &owner, 7),
+                Err(Error::DuplicateRecord)
+            );
+            assert_eq!(get_owner_portfolio(env, &owner).len(), 1);
+        });
+    }
+
+    #[test]
+    fn portfolios_are_isolated_per_owner() {
+        with_contract(|env| {
+            let alice = Address::generate(env);
+            let bob = Address::generate(env);
+            add_token_to_owner(env, &alice, 1).unwrap();
+            add_token_to_owner(env, &bob, 2).unwrap();
+
+            assert!(owner_contains_token(env, &alice, 1));
+            assert!(!owner_contains_token(env, &alice, 2));
+            assert_eq!(get_owner_portfolio(env, &bob).get(0).unwrap(), 2);
+        });
+    }
+
+    #[test]
+    fn empty_portfolio_for_unknown_owner() {
+        with_contract(|env| {
+            let owner = Address::generate(env);
+            assert_eq!(get_owner_portfolio(env, &owner).len(), 0);
+        });
+    }
+}

--- a/clips_nft/src/royalty_percentage.rs
+++ b/clips_nft/src/royalty_percentage.rs
@@ -1,0 +1,102 @@
+//! Per-token royalty percentage storage (issue #673).
+//!
+//! Persists the royalty percentage — expressed in basis points (bps), matching
+//! the rest of the contract — associated with every minted NFT, validates it
+//! against the allowed maximum, and reads it back.
+//!
+//! # Storage
+//! Key: `DataKey::RoyaltyPercentage(token_id)` (persistent storage)
+//!
+//! # Limits
+//! `0` – `10_000` bps inclusive (0 % – 100 %).
+
+use soroban_sdk::Env;
+
+use crate::storage_constants::MAX_ROYALTY_BPS;
+use crate::types::{DataKey, Error, TokenId};
+
+/// Persist the royalty percentage (in basis points) for `token_id`.
+///
+/// # Errors
+/// Returns [`Error::InvalidBasisPoints`] when `bps > MAX_ROYALTY_BPS`.
+pub fn set_royalty_percentage(env: &Env, token_id: TokenId, bps: u32) -> Result<(), Error> {
+    if bps > MAX_ROYALTY_BPS {
+        return Err(Error::InvalidBasisPoints);
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::RoyaltyPercentage(token_id), &bps);
+    Ok(())
+}
+
+/// Return the royalty percentage (in basis points) for `token_id`.
+///
+/// # Errors
+/// Returns [`Error::TokenNotFound`] if no percentage has been recorded.
+pub fn get_royalty_percentage(env: &Env, token_id: TokenId) -> Result<u32, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RoyaltyPercentage(token_id))
+        .ok_or(Error::TokenNotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AtomicMintContract;
+    use soroban_sdk::Env;
+
+    fn with_contract<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Env) -> R,
+    {
+        let env = Env::default();
+        let contract_id = env.register(AtomicMintContract, ());
+        env.as_contract(&contract_id, || f(&env))
+    }
+
+    #[test]
+    fn stores_and_retrieves_percentage() {
+        with_contract(|env| {
+            set_royalty_percentage(env, 1, 500).unwrap();
+            assert_eq!(get_royalty_percentage(env, 1).unwrap(), 500);
+        });
+    }
+
+    #[test]
+    fn accepts_boundary_values() {
+        with_contract(|env| {
+            set_royalty_percentage(env, 1, 0).unwrap();
+            assert_eq!(get_royalty_percentage(env, 1).unwrap(), 0);
+
+            set_royalty_percentage(env, 2, MAX_ROYALTY_BPS).unwrap();
+            assert_eq!(get_royalty_percentage(env, 2).unwrap(), MAX_ROYALTY_BPS);
+        });
+    }
+
+    #[test]
+    fn rejects_percentage_above_limit() {
+        with_contract(|env| {
+            assert_eq!(
+                set_royalty_percentage(env, 1, MAX_ROYALTY_BPS + 1),
+                Err(Error::InvalidBasisPoints)
+            );
+        });
+    }
+
+    #[test]
+    fn overwrites_existing_percentage() {
+        with_contract(|env| {
+            set_royalty_percentage(env, 1, 250).unwrap();
+            set_royalty_percentage(env, 1, 750).unwrap();
+            assert_eq!(get_royalty_percentage(env, 1).unwrap(), 750);
+        });
+    }
+
+    #[test]
+    fn missing_percentage_returns_not_found() {
+        with_contract(|env| {
+            assert_eq!(get_royalty_percentage(env, 99), Err(Error::TokenNotFound));
+        });
+    }
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -173,6 +173,20 @@ pub enum DataKey {
     UsedSignature(BytesN<32>),
     /// Wallet ownership index: wallet → Vec<TokenId>.
     WalletTokens(Address),
+
+    // ── Minting storage tasks (issues #673–#676) ──────────────────────────────
+    /// Per-token royalty percentage in basis points (issue #673).
+    RoyaltyPercentage(TokenId),
+    /// Portfolio index of tokens created by a creator (issue #674).
+    CreatorTokens(Address),
+    /// Portfolio index of tokens owned by an address (issue #675).
+    OwnerTokens(Address),
+    /// Collection a token is associated with (issue #676).
+    TokenCollection(TokenId),
+    /// Existence marker for a registered collection (issue #676).
+    CollectionRegistered(u32),
+    /// Membership list of tokens in a collection (issue #676).
+    CollectionMembers(u32),
 }
 
 #[contracterror]
@@ -241,4 +255,6 @@ pub enum Error {
     UnsupportedProtocol = 21,
     /// URL is malformed or invalid.
     MalformedUrl = 22,
+    /// The referenced collection has not been registered (issue #676).
+    CollectionNotFound = 40,
 }


### PR DESCRIPTION
## Summary

Implements four **Stellar Wave** minting-storage tasks as self-contained, additive storage modules that follow the existing repo conventions (see `wallet_token_index.rs`, `default_royalty.rs`, `collection_supply.rs`).

| Issue | Module | What it does |
|------|--------|--------------|
| #673 | `royalty_percentage.rs` | Persist a per-token royalty percentage (basis points), validate against `MAX_ROYALTY_BPS`, retrieve. |
| #674 | `creator_portfolio.rs` | Maintain an index of tokens created by each creator; prevent duplicates; retrieve the full portfolio. |
| #675 | `owner_portfolio.rs` | Update the owner's NFT index after mint; preserve insertion order; prevent duplicates; retrieve portfolio. |
| #676 | `nft_collection.rs` | Register a collection, validate it exists, associate NFTs (saving the collection reference), and retrieve collection membership. |

Each module ships with inline unit tests covering the acceptance criteria (store/retrieve, duplicate prevention, ordering, and boundary/limit validation).

## Changes
- **4 new modules** under `clips_nft/src/`.
- `lib.rs`: wire in the four new modules (additive).
- `types.rs`: add the supporting `DataKey` variants (`RoyaltyPercentage`, `CreatorTokens`, `OwnerTokens`, `TokenCollection`, `CollectionRegistered`, `CollectionMembers`) and a `CollectionNotFound` error (additive).

The change set is **purely additive** (+22 lines to existing files, no deletions) and does not touch unrelated code.

> ⚠️ Note: `main` currently does not compile due to pre-existing merge damage in unrelated modules (garbage block in `lib.rs`, duplicate variants in `types.rs`, a stray token in `metadata/mod.rs`, a `config.rs`/`config/mod.rs` conflict, and `std`-only code in the metadata JSON builder). Per request, this PR intentionally does **not** attempt to repair that. Once `main` builds, these modules and their tests compile as-is.

Closes #673
Closes #674
Closes #675
Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)