### PR TITLE
feat(events): emit RoyaltyAssigned event on mint (#695)

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -12,11 +12,10 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, Strin
 // ─── Core types ───────────────────────────────────────────────────────────────
 pub mod types;
 pub use types::{
-    BatchId, BatchMintResponse, BurnEvent, DataKey, Error, MetadataUpdatedEvent, MintEvent,
-    MintSuccessResponse, Royalty, RoyaltyInfo, RoyaltyPaidEvent, RoyaltyPayment, TokenData,
-    TokenId, TransactionStatus, TransferEvent,
-    BurnEvent, DataKey, Error, MetadataUpdatedEvent, MintEvent, NFTMintedEvent, Royalty,
-    RoyaltyInfo, RoyaltyPaidEvent, RoyaltyPayment, TokenData, TokenId, TransferEvent,
+    BatchId, BatchMintResponse, BurnEvent, CreatorAssignedEvent, DataKey, Error,
+    MetadataUpdatedEvent, MintEvent, MintSuccessResponse, NFTMintedEvent, Royalty, RoyaltyAssignedEvent,
+    RoyaltyInfo, RoyaltyPaidEvent, RoyaltyPayment, TokenData, TokenId, TransactionStatus,
+    TransferEvent,
 };
 pub mod contract_version;
 pub mod default_royalty;
@@ -36,9 +35,9 @@ pub mod mint_service;
 pub use mint_service::{execute_batch_mint, execute_mint, execute_mint_with_media, MintResult};
 
 pub mod mint_event;
+pub mod royalty_assigned_event;
 pub mod mint_validator;
 pub use mint_validator::{validate_batch_mint, validate_mint, validate_mint_request};
-pub mod mint_authorization;
 
 // ─── Storage modules ──────────────────────────────────────────────────────────
 pub mod clip_id_storage;
@@ -91,9 +90,8 @@ pub mod config_validator;
 pub mod storage_constants;
 pub use storage_constants::{
     CONTRACT_VERSION, CURRENT_MIGRATION_VERSION, DEFAULT_NEXT_BATCH_ID, DEFAULT_ROYALTY_BPS,
-    DEFAULT_TOTAL_SUPPLY, INITIAL_MIGRATION_VERSION, MAX_COLLECTION_LIMIT, MAX_ROYALTY_BPS,
-    CONTRACT_VERSION, CURRENT_MIGRATION_VERSION, DEFAULT_ROYALTY_BPS, DEFAULT_TOTAL_SUPPLY,
-    INITIAL_MIGRATION_VERSION, MAX_BATCH_TRANSFER_SIZE, MAX_COLLECTION_LIMIT, MAX_ROYALTY_BPS,
+    DEFAULT_TOTAL_SUPPLY, INITIAL_MIGRATION_VERSION, MAX_BATCH_TRANSFER_SIZE,
+    MAX_COLLECTION_LIMIT, MAX_ROYALTY_BPS,
 };
 /// Alias for [`CONTRACT_VERSION`]; retained for backward compatibility.
 pub use storage_constants::CONTRACT_VERSION as VERSION;

--- a/clips_nft/src/mint_service.rs
+++ b/clips_nft/src/mint_service.rs
@@ -20,8 +20,8 @@ use soroban_sdk::{contracttype, Address, Env, String, Vec};
 use crate::{
     batch_id_storage, clip_id_storage, creator_portfolio, creator_storage, mint_event,
     mint_validator, mint_request::{BatchMintRequest, MintRequest}, owner_portfolio,
-    preview_video_uri, royalty_percentage, royalty_recipient, thumbnail_uri, token_storage,
-    total_supply,
+    preview_video_uri, royalty_assigned_event, royalty_percentage, royalty_recipient,
+    thumbnail_uri, token_storage, total_supply,
     types::{
         BatchMintResponse, DataKey, Error, MintSuccessResponse, TokenData, TokenId,
         TransactionStatus,
@@ -326,6 +326,18 @@ fn execute_mint_inner(
         token_id,
         request.royalty_info.basis_points,
     )?;
+
+    // 4a-event. Emit royalty-assigned event now that all royalty writes are
+    //           complete (issue #695).  Emitted before any further writes so
+    //           subscribers know the royalty is persisted even if a later
+    //           step panics (Soroban rolls back state but not event queues).
+    royalty_assigned_event::emit_royalty_assigned(
+        env,
+        token_id,
+        &request.royalty_info.recipient,
+        request.royalty_info.basis_points,
+        env.ledger().timestamp(),
+    );
 
     // 4b. Record creator metadata (single write — includes address + display_name).
     //     If creator_address is provided use it; otherwise default to the owner.

--- a/clips_nft/src/royalty_assigned_event.rs
+++ b/clips_nft/src/royalty_assigned_event.rs
@@ -1,0 +1,132 @@
+//! Royalty-assigned event — emitted when royalty is successfully assigned during minting.
+//!
+//! Resolves issue #695: emit a `"ryl_asgn"` event every time royalty
+//! information is persisted as part of the mint pipeline.  Off-chain indexers
+//! and marketplaces can subscribe to this event to track royalty configurations
+//! at creation time without needing additional storage reads.
+//!
+//! # Event topic
+//! `"ryl_asgn"` — 8 characters, well within the 9-character limit for
+//! [`soroban_sdk::symbol_short`].
+//!
+//! # Event data
+//! [`RoyaltyAssignedEvent`] — token ID, recipient address, basis points, and ledger
+//! timestamp.
+
+use soroban_sdk::{symbol_short, Address, Env};
+
+use crate::types::{RoyaltyAssignedEvent, TokenId};
+
+/// Emit the `"ryl_asgn"` event after royalty has been persisted for a token.
+///
+/// Must be called **after** all royalty storage writes have completed so that
+/// receiving the event guarantees the royalty is already queryable on-chain.
+///
+/// # Arguments
+/// * `env`          — Contract execution environment.
+/// * `token_id`     — On-chain token ID the royalty was assigned to.
+/// * `recipient`    — Address that will receive royalty payments.
+/// * `basis_points` — Royalty percentage in basis points (0–10 000).
+/// * `timestamp`    — Ledger timestamp in seconds since the Unix epoch.
+pub fn emit_royalty_assigned(
+    env: &Env,
+    token_id: TokenId,
+    recipient: &Address,
+    basis_points: u32,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("ryl_asgn"),),
+        RoyaltyAssignedEvent {
+            token_id,
+            recipient: recipient.clone(),
+            basis_points,
+            timestamp,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::RoyaltyAssignedEvent;
+    use crate::AtomicMintContract;
+    use soroban_sdk::{
+        testutils::{Address as _, Events},
+        Address, Env,
+    };
+
+    fn setup() -> (Env, soroban_sdk::Address) {
+        let env = Env::default();
+        let contract_id = env.register(AtomicMintContract, ());
+        (env, contract_id)
+    }
+
+    #[test]
+    fn emit_royalty_assigned_publishes_event() {
+        let (env, contract_id) = setup();
+        env.as_contract(&contract_id, || {
+            let recipient = Address::generate(&env);
+            emit_royalty_assigned(&env, 1, &recipient, 500, 1_700_000_000);
+            assert_eq!(env.events().all().events().len(), 1);
+        });
+    }
+
+    #[test]
+    fn emit_royalty_assigned_event_fields_match() {
+        let (env, contract_id) = setup();
+        env.as_contract(&contract_id, || {
+            let recipient = Address::generate(&env);
+            let token_id: TokenId = 42;
+            let basis_points: u32 = 750;
+            let timestamp: u64 = 1_720_000_000;
+
+            emit_royalty_assigned(&env, token_id, &recipient, basis_points, timestamp);
+
+            let all = env.events().all();
+            assert_eq!(all.events().len(), 1);
+
+            let (_, data): (soroban_sdk::Vec<soroban_sdk::Val>, RoyaltyAssignedEvent) =
+                all.events().get(0).unwrap();
+            assert_eq!(data.token_id, token_id);
+            assert_eq!(data.recipient, recipient);
+            assert_eq!(data.basis_points, basis_points);
+            assert_eq!(data.timestamp, timestamp);
+        });
+    }
+
+    #[test]
+    fn emit_royalty_assigned_zero_bps_is_valid() {
+        let (env, contract_id) = setup();
+        env.as_contract(&contract_id, || {
+            let recipient = Address::generate(&env);
+            // 0 bps (no royalty) is a legitimate value and should still emit.
+            emit_royalty_assigned(&env, 5, &recipient, 0, 1_700_000_001);
+            assert_eq!(env.events().all().events().len(), 1);
+        });
+    }
+
+    #[test]
+    fn emit_royalty_assigned_max_bps_is_valid() {
+        let (env, contract_id) = setup();
+        env.as_contract(&contract_id, || {
+            let recipient = Address::generate(&env);
+            // 10_000 bps = 100 %; already validated upstream, just verify emission.
+            emit_royalty_assigned(&env, 99, &recipient, 10_000, 1_700_000_002);
+            let all = env.events().all();
+            assert_eq!(all.events().len(), 1);
+            let (_, data): (soroban_sdk::Vec<soroban_sdk::Val>, RoyaltyAssignedEvent) =
+                all.events().get(0).unwrap();
+            assert_eq!(data.basis_points, 10_000);
+        });
+    }
+
+    #[test]
+    fn no_event_emitted_without_calling_function() {
+        let (env, contract_id) = setup();
+        env.as_contract(&contract_id, || {
+            // Sanity check: no spurious events appear on a clean environment.
+            assert_eq!(env.events().all().events().len(), 0);
+        });
+    }
+}

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -121,6 +121,29 @@ pub struct RoyaltyPaidEvent {
     pub asset_address: Option<Address>,
 }
 
+/// Event emitted when royalty information is successfully assigned during minting (issue #695).
+///
+/// Carries every field an indexer needs to track royalty configuration at
+/// mint time, without requiring additional storage reads.
+///
+/// # Fields
+/// - `token_id`     — On-chain token identifier the royalty is assigned to.
+/// - `recipient`    — Address that will receive royalty payments.
+/// - `basis_points` — Royalty percentage in basis points (100 bps = 1 %).
+/// - `timestamp`    — Ledger timestamp (seconds since Unix epoch) when assigned.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoyaltyAssignedEvent {
+    /// On-chain token ID the royalty is assigned to.
+    pub token_id: TokenId,
+    /// Address that will receive royalty payments on secondary sales.
+    pub recipient: Address,
+    /// Royalty percentage in basis points (0–10 000).
+    pub basis_points: u32,
+    /// Ledger timestamp in seconds since the Unix epoch.
+    pub timestamp: u64,
+}
+
 /// Event emitted when a creator is assigned to a newly minted NFT.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/clips_nft/tests/test_royalty_assigned_event.rs
+++ b/clips_nft/tests/test_royalty_assigned_event.rs
@@ -1,0 +1,205 @@
+//! Integration tests for the RoyaltyAssigned event (issue #695).
+//!
+//! Verifies that a `"rylty_asgn"` event is emitted — with the correct
+//! token ID, royalty recipient, basis points, and timestamp — every time a
+//! successful mint persists royalty information.
+
+#![cfg(test)]
+
+use clips_nft::{
+    mint_service::execute_mint, types::RoyaltyAssignedEvent, MintRequest, Royalty,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger, LedgerInfo},
+    symbol_short, Address, Env, String, Val, Vec,
+};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_request(env: &Env, owner: &Address, recipient: &Address, clip_id: u32, bps: u32) -> MintRequest {
+    MintRequest {
+        clip_id,
+        owner: owner.clone(),
+        creator: owner.clone(),
+        metadata_uri: String::from_str(env, &format!("ipfs://QmClip{}", clip_id)),
+        thumbnail_uri: None,
+        preview_video_uri: None,
+        royalty_info: Royalty {
+            recipient: recipient.clone(),
+            basis_points: bps,
+            asset_address: None,
+        },
+    }
+}
+
+// ─── Event emission ───────────────────────────────────────────────────────────
+
+/// After a successful mint the event list must contain a `"rylty_asgn"` entry.
+#[test]
+fn test_royalty_assigned_event_emitted_on_mint() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let result = execute_mint(&env, make_request(&env, &owner, &recipient, 1, 500))
+        .expect("mint should succeed");
+
+    let all = env.events().all();
+    // At minimum the royalty-assigned event should be present (there will also
+    // be the mint event, but we only care that ours is there).
+    let royalty_events: Vec<(Vec<Val>, RoyaltyAssignedEvent)> = all
+        .events()
+        .iter()
+        .filter_map(|(topics, data): (Vec<Val>, RoyaltyAssignedEvent)| {
+            Some((topics, data))
+        })
+        .filter(|(_, data)| data.token_id == result.token_id)
+        .collect();
+
+    assert!(
+        !royalty_events.is_empty(),
+        "expected at least one RoyaltyAssignedEvent for token {}",
+        result.token_id
+    );
+}
+
+/// The event fields must exactly match the values supplied in the mint request.
+#[test]
+fn test_royalty_assigned_event_fields_are_correct() {
+    let env = Env::default();
+    env.ledger().set(LedgerInfo {
+        timestamp: 1_720_000_000,
+        protocol_version: 21,
+        sequence_number: 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 3_110_400,
+    });
+
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let basis_points: u32 = 750;
+
+    let result = execute_mint(&env, make_request(&env, &owner, &recipient, 2, basis_points))
+        .expect("mint should succeed");
+
+    // Find the RoyaltyAssignedEvent for this token among all published events.
+    let mut found: Option<RoyaltyAssignedEvent> = None;
+    for i in 0..env.events().all().events().len() {
+        if let Ok((_, evt)) =
+            env.events()
+                .all()
+                .events()
+                .get(i)
+                .map(|(t, d): (Vec<Val>, RoyaltyAssignedEvent)| (t, d))
+        {
+            if evt.token_id == result.token_id {
+                found = Some(evt);
+                break;
+            }
+        }
+    }
+
+    let evt = found.expect("RoyaltyAssignedEvent not found in emitted events");
+    assert_eq!(evt.token_id, result.token_id, "token_id mismatch");
+    assert_eq!(evt.recipient, recipient, "recipient mismatch");
+    assert_eq!(evt.basis_points, basis_points, "basis_points mismatch");
+    assert_eq!(evt.timestamp, 1_720_000_000, "timestamp mismatch");
+}
+
+/// Zero basis points (no royalty) should still emit the event so indexers can
+/// record the explicit royalty-free assignment.
+#[test]
+fn test_royalty_assigned_event_emitted_for_zero_bps() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let result = execute_mint(&env, make_request(&env, &owner, &recipient, 3, 0))
+        .expect("mint with zero bps should succeed");
+
+    // At least one event must be present and one of them must be for this token.
+    assert!(
+        env.events().all().events().len() > 0,
+        "no events emitted at all"
+    );
+
+    let found = env
+        .events()
+        .all()
+        .events()
+        .iter()
+        .filter_map(|(_, data): (Vec<Val>, RoyaltyAssignedEvent)| Some(data))
+        .any(|e| e.token_id == result.token_id && e.basis_points == 0);
+
+    assert!(found, "expected RoyaltyAssignedEvent with basis_points=0");
+}
+
+/// Each token minted in separate calls must emit its own event, each with the
+/// correct token_id.
+#[test]
+fn test_royalty_assigned_event_emitted_per_mint() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let res1 = execute_mint(&env, make_request(&env, &owner, &r1, 10, 500))
+        .expect("first mint ok");
+    let res2 = execute_mint(&env, make_request(&env, &owner, &r2, 11, 1000))
+        .expect("second mint ok");
+
+    let token_ids_in_events: Vec<u32> = env
+        .events()
+        .all()
+        .events()
+        .iter()
+        .filter_map(|(_, data): (Vec<Val>, RoyaltyAssignedEvent)| Some(data.token_id))
+        .collect();
+
+    assert!(
+        token_ids_in_events.contains(&res1.token_id),
+        "no event for first minted token {}",
+        res1.token_id
+    );
+    assert!(
+        token_ids_in_events.contains(&res2.token_id),
+        "no event for second minted token {}",
+        res2.token_id
+    );
+}
+
+/// The timestamp on the event must reflect the ledger time at the point of minting.
+#[test]
+fn test_royalty_assigned_event_timestamp_matches_ledger() {
+    let env = Env::default();
+    env.ledger().set(LedgerInfo {
+        timestamp: 9_999_999,
+        protocol_version: 21,
+        sequence_number: 5,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 3_110_400,
+    });
+
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let result = execute_mint(&env, make_request(&env, &owner, &recipient, 20, 300))
+        .expect("mint ok");
+
+    let evt: RoyaltyAssignedEvent = env
+        .events()
+        .all()
+        .events()
+        .iter()
+        .filter_map(|(_, d): (Vec<Val>, RoyaltyAssignedEvent)| Some(d))
+        .find(|e| e.token_id == result.token_id)
+        .expect("RoyaltyAssignedEvent not found");
+
+    assert_eq!(evt.timestamp, 9_999_999, "event timestamp must match ledger timestamp");
+}


### PR DESCRIPTION
## Summary

Resolves #695.

Emits a `ryl_asgn` event every time royalty information is successfully persisted during minting. The event carries all four fields required by the acceptance criteria.

## Changes

### New: `RoyaltyAssignedEvent` (types.rs)
```rust
pub struct RoyaltyAssignedEvent {
    pub token_id: TokenId,   // token ID
    pub recipient: Address,  // royalty recipient
    pub basis_points: u32,   // royalty BPS
    pub timestamp: u64,      // ledger timestamp
}
```

### New: `royalty_assigned_event.rs`
- `emit_royalty_assigned()` publishes the event under topic `"ryl_asgn"`
- Called in `execute_mint_inner` immediately after both royalty storage writes (`set_royalty` + `set_royalty_percentage`) complete, so the event is only emitted when royalty is durably on-chain
- Applies to single mints and every item in a batch mint

### New: `tests/test_royalty_assigned_event.rs`
5 integration tests:
- Event is emitted on a successful mint
- All four fields match the mint request values exactly
- Zero BPS emits the event (explicit royalty-free assignment)
- One event emitted per token across multiple mints
- Timestamp matches the configured ledger time

### `lib.rs`
- Registered `pub mod royalty_assigned_event`
- Added `RoyaltyAssignedEvent` to the crate re-exports
- Fixed two pre-existing duplicate `pub use` blocks (`types`, `storage_constants`) and a duplicate `pub mod mint_authorization` that would have caused compile errors

## Testing

Unit tests are embedded in `royalty_assigned_event.rs`. Integration tests are in `clips_nft/tests/test_royalty_assigned_event.rs`.