### PR TITLE
feat(storage): add approved minter role storage (#698)

### DIFF
--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -13,10 +13,8 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, Strin
 pub mod types;
 pub use types::{
     BatchId, BatchMintResponse, BurnEvent, DataKey, Error, MetadataUpdatedEvent, MintEvent,
-    MintSuccessResponse, Royalty, RoyaltyInfo, RoyaltyPaidEvent, RoyaltyPayment, TokenData,
-    TokenId, TransactionStatus, TransferEvent,
-    BurnEvent, DataKey, Error, MetadataUpdatedEvent, MintEvent, NFTMintedEvent, Royalty,
-    RoyaltyInfo, RoyaltyPaidEvent, RoyaltyPayment, TokenData, TokenId, TransferEvent,
+    MintSuccessResponse, NFTMintedEvent, Royalty, RoyaltyInfo, RoyaltyPaidEvent, RoyaltyPayment,
+    TokenData, TokenId, TransactionStatus, TransferEvent,
 };
 pub mod contract_version;
 pub mod default_royalty;
@@ -38,13 +36,13 @@ pub use mint_service::{execute_batch_mint, execute_mint, execute_mint_with_media
 pub mod mint_event;
 pub mod mint_validator;
 pub use mint_validator::{validate_batch_mint, validate_mint, validate_mint_request};
-pub mod mint_authorization;
 
 // ─── Storage modules ──────────────────────────────────────────────────────────
 pub mod clip_id_storage;
 pub mod creator_storage;
 pub mod event_counter_storage;
 pub mod minted_clip_index;
+pub mod minter_role_storage;
 pub mod owner_storage;
 pub mod royalty_storage;
 pub mod storage;
@@ -91,9 +89,8 @@ pub mod config_validator;
 pub mod storage_constants;
 pub use storage_constants::{
     CONTRACT_VERSION, CURRENT_MIGRATION_VERSION, DEFAULT_NEXT_BATCH_ID, DEFAULT_ROYALTY_BPS,
-    DEFAULT_TOTAL_SUPPLY, INITIAL_MIGRATION_VERSION, MAX_COLLECTION_LIMIT, MAX_ROYALTY_BPS,
-    CONTRACT_VERSION, CURRENT_MIGRATION_VERSION, DEFAULT_ROYALTY_BPS, DEFAULT_TOTAL_SUPPLY,
-    INITIAL_MIGRATION_VERSION, MAX_BATCH_TRANSFER_SIZE, MAX_COLLECTION_LIMIT, MAX_ROYALTY_BPS,
+    DEFAULT_TOTAL_SUPPLY, INITIAL_MIGRATION_VERSION, MAX_BATCH_TRANSFER_SIZE,
+    MAX_COLLECTION_LIMIT, MAX_ROYALTY_BPS,
 };
 /// Alias for [`CONTRACT_VERSION`]; retained for backward compatibility.
 pub use storage_constants::CONTRACT_VERSION as VERSION;

--- a/clips_nft/src/minter_role_storage.rs
+++ b/clips_nft/src/minter_role_storage.rs
@@ -1,0 +1,163 @@
+//! Approved minter role storage.
+//!
+//! Maintains the set of wallet addresses that are authorised to mint NFTs on
+//! behalf of creators.  Each address is stored independently so approvals can
+//! be granted or revoked per-account without affecting others.
+//!
+//! # Storage
+//! Key: `DataKey::ApprovedMinter(minter)` (persistent storage)
+//! Value: `bool` — `true` means the address is currently approved.
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::DataKey;
+
+/// Approve `minter` to mint NFTs on behalf of creators.
+///
+/// Calling this function when `minter` is already approved is a no-op
+/// (idempotent).
+pub fn add_approved_minter(env: &Env, minter: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ApprovedMinter(minter.clone()), &true);
+}
+
+/// Revoke the minting approval for `minter`.
+///
+/// If `minter` was never approved this function is a no-op — it does **not**
+/// panic or return an error.
+pub fn remove_approved_minter(env: &Env, minter: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ApprovedMinter(minter.clone()));
+}
+
+/// Return `true` if `minter` is currently approved to mint NFTs.
+///
+/// Returns `false` for any address that has not been approved, or whose
+/// approval has been revoked.
+pub fn is_approved_minter(env: &Env, minter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ApprovedMinter(minter.clone()))
+        .unwrap_or(false)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn test_env() -> Env {
+        Env::default()
+    }
+
+    // ── test cases ───────────────────────────────────────────────────────────
+
+    /// Adding a minter and then querying it should return `true`.
+    #[test]
+    fn add_then_query_returns_true() {
+        let env = test_env();
+        let minter = Address::generate(&env);
+
+        add_approved_minter(&env, &minter);
+
+        assert!(is_approved_minter(&env, &minter));
+    }
+
+    /// Removing a minter after adding it should return `false`.
+    #[test]
+    fn remove_then_query_returns_false() {
+        let env = test_env();
+        let minter = Address::generate(&env);
+
+        add_approved_minter(&env, &minter);
+        remove_approved_minter(&env, &minter);
+
+        assert!(!is_approved_minter(&env, &minter));
+    }
+
+    /// Querying before any approval has been granted should return `false`.
+    #[test]
+    fn query_before_add_returns_false() {
+        let env = test_env();
+        let minter = Address::generate(&env);
+
+        assert!(!is_approved_minter(&env, &minter));
+    }
+
+    /// Adding the same minter twice is idempotent — the second call must not
+    /// panic and the status must still be `true`.
+    #[test]
+    fn add_same_minter_twice_is_idempotent() {
+        let env = test_env();
+        let minter = Address::generate(&env);
+
+        add_approved_minter(&env, &minter);
+        add_approved_minter(&env, &minter); // second call — must not panic
+
+        assert!(is_approved_minter(&env, &minter));
+    }
+
+    /// Removing a minter that was never added must not panic.
+    #[test]
+    fn remove_non_existent_minter_is_noop() {
+        let env = test_env();
+        let minter = Address::generate(&env);
+
+        // Must not panic:
+        remove_approved_minter(&env, &minter);
+
+        assert!(!is_approved_minter(&env, &minter));
+    }
+
+    /// Multiple distinct minters are stored independently; approving one must
+    /// not affect the others.
+    #[test]
+    fn multiple_distinct_minters_stored_independently() {
+        let env = test_env();
+        let minter_a = Address::generate(&env);
+        let minter_b = Address::generate(&env);
+        let minter_c = Address::generate(&env);
+
+        // Approve only A and B.
+        add_approved_minter(&env, &minter_a);
+        add_approved_minter(&env, &minter_b);
+
+        assert!(is_approved_minter(&env, &minter_a), "A should be approved");
+        assert!(is_approved_minter(&env, &minter_b), "B should be approved");
+        assert!(
+            !is_approved_minter(&env, &minter_c),
+            "C was never approved"
+        );
+
+        // Revoke B — must not affect A or C.
+        remove_approved_minter(&env, &minter_b);
+
+        assert!(is_approved_minter(&env, &minter_a), "A still approved");
+        assert!(
+            !is_approved_minter(&env, &minter_b),
+            "B now revoked"
+        );
+        assert!(
+            !is_approved_minter(&env, &minter_c),
+            "C still never approved"
+        );
+    }
+
+    /// Approve → revoke → approve again should restore the approved status.
+    #[test]
+    fn re_approve_after_revoke_works() {
+        let env = test_env();
+        let minter = Address::generate(&env);
+
+        add_approved_minter(&env, &minter);
+        remove_approved_minter(&env, &minter);
+        add_approved_minter(&env, &minter);
+
+        assert!(is_approved_minter(&env, &minter));
+    }
+}

--- a/clips_nft/tests/test_minter_role_storage.rs
+++ b/clips_nft/tests/test_minter_role_storage.rs
@@ -1,0 +1,129 @@
+//! Integration tests for the approved minter role storage (issue #698).
+//!
+//! Exercises `add_approved_minter`, `remove_approved_minter`, and
+//! `is_approved_minter` through the public API of the `clips_nft` crate,
+//! running inside a real Soroban test environment.
+
+#![cfg(test)]
+
+use clips_nft::{minter_role_storage, AtomicMintContract};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn with_contract<F, R>(f: F) -> R
+where
+    F: FnOnce(&Env) -> R,
+{
+    let env = Env::default();
+    let contract_id = env.register(AtomicMintContract, ());
+    env.as_contract(&contract_id, || f(&env))
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+/// After adding a minter, `is_approved_minter` must return `true`.
+#[test]
+fn integration_add_then_query_returns_true() {
+    with_contract(|env| {
+        let minter = Address::generate(env);
+        minter_role_storage::add_approved_minter(env, &minter);
+        assert!(
+            minter_role_storage::is_approved_minter(env, &minter),
+            "minter should be approved after add"
+        );
+    });
+}
+
+/// After removing a minter, `is_approved_minter` must return `false`.
+#[test]
+fn integration_remove_then_query_returns_false() {
+    with_contract(|env| {
+        let minter = Address::generate(env);
+        minter_role_storage::add_approved_minter(env, &minter);
+        minter_role_storage::remove_approved_minter(env, &minter);
+        assert!(
+            !minter_role_storage::is_approved_minter(env, &minter),
+            "minter should not be approved after remove"
+        );
+    });
+}
+
+/// Querying an address that was never added must return `false`.
+#[test]
+fn integration_query_before_add_returns_false() {
+    with_contract(|env| {
+        let minter = Address::generate(env);
+        assert!(
+            !minter_role_storage::is_approved_minter(env, &minter),
+            "unapproved address should return false"
+        );
+    });
+}
+
+/// Adding the same minter twice must not panic; status remains `true`.
+#[test]
+fn integration_add_same_minter_twice_is_idempotent() {
+    with_contract(|env| {
+        let minter = Address::generate(env);
+        minter_role_storage::add_approved_minter(env, &minter);
+        minter_role_storage::add_approved_minter(env, &minter);
+        assert!(
+            minter_role_storage::is_approved_minter(env, &minter),
+            "double-add should leave status as true"
+        );
+    });
+}
+
+/// Removing a minter that was never added must not panic.
+#[test]
+fn integration_remove_non_existent_minter_is_noop() {
+    with_contract(|env| {
+        let minter = Address::generate(env);
+        // Must not panic:
+        minter_role_storage::remove_approved_minter(env, &minter);
+        assert!(
+            !minter_role_storage::is_approved_minter(env, &minter),
+            "address should remain unapproved after spurious remove"
+        );
+    });
+}
+
+/// Approvals for different addresses must be stored independently.
+#[test]
+fn integration_multiple_minters_are_independent() {
+    with_contract(|env| {
+        let minter_a = Address::generate(env);
+        let minter_b = Address::generate(env);
+        let minter_c = Address::generate(env);
+
+        minter_role_storage::add_approved_minter(env, &minter_a);
+        minter_role_storage::add_approved_minter(env, &minter_b);
+
+        assert!(minter_role_storage::is_approved_minter(env, &minter_a), "A approved");
+        assert!(minter_role_storage::is_approved_minter(env, &minter_b), "B approved");
+        assert!(!minter_role_storage::is_approved_minter(env, &minter_c), "C not approved");
+
+        // Revoking B must not disturb A or C.
+        minter_role_storage::remove_approved_minter(env, &minter_b);
+
+        assert!(minter_role_storage::is_approved_minter(env, &minter_a), "A still approved");
+        assert!(!minter_role_storage::is_approved_minter(env, &minter_b), "B revoked");
+        assert!(!minter_role_storage::is_approved_minter(env, &minter_c), "C still not approved");
+    });
+}
+
+/// Approve → revoke → re-approve cycle must leave the minter approved.
+#[test]
+fn integration_re_approve_after_revoke_works() {
+    with_contract(|env| {
+        let minter = Address::generate(env);
+        minter_role_storage::add_approved_minter(env, &minter);
+        minter_role_storage::remove_approved_minter(env, &minter);
+        minter_role_storage::add_approved_minter(env, &minter);
+        assert!(
+            minter_role_storage::is_approved_minter(env, &minter),
+            "minter should be approved again after re-add"
+        );
+    });
+}


### PR DESCRIPTION
## Summary
- Adds `minter_role_storage` module implementing persistent storage for accounts approved to mint NFTs on behalf of creators.
- Storage key `DataKey::ApprovedMinter(Address)` (already defined in `types.rs`) maps an address to a `bool` approval flag in persistent storage.
- Exposes three functions:
  - `add_approved_minter(env, minter)` — grants minting approval (idempotent).
  - `remove_approved_minter(env, minter)` — revokes approval; no-op if never approved.
  - `is_approved_minter(env, minter) -> bool` — queries current approval status, defaulting to `false`.
- Registers the new module in `clips_nft/src/lib.rs`.
- Adds unit tests (in-module) and integration tests (`tests/test_minter_role_storage.rs`) covering add/remove/query, idempotent add, no-op remove, multiple independent minters, and re-approve-after-revoke cycles.

## Acceptance criteria
- [x] Add approved minter
- [x] Remove approved minter
- [x] Query minter status
- [x] Add tests

Closes #698