### PR TITLE
feat(storage): implement administrator storage for multiple admins

### DIFF
--- a/clips_nft/src/administrator_storage.rs
+++ b/clips_nft/src/administrator_storage.rs
@@ -1,0 +1,121 @@
+//! Approved administrator storage.
+//!
+//! Maintains the set of wallet addresses that are authorised as administrators.
+//! Each address is stored independently in persistent storage so approvals can
+//! be granted or revoked per-account.
+//!
+//! # Storage
+//! Key: `DataKey::Administrator(admin)` (persistent storage)
+//! Value: `bool` — `true` means the address is currently an admin.
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::DataKey;
+
+/// Add an administrator account.
+///
+/// Calling this function when `admin` is already an administrator is a no-op.
+pub fn add_admin(env: &Env, admin: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Administrator(admin.clone()), &true);
+}
+
+/// Remove an administrator account.
+///
+/// If `admin` was never an administrator, this function is a no-op.
+pub fn remove_admin(env: &Env, admin: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Administrator(admin.clone()));
+}
+
+/// Check if the address is currently an administrator.
+pub fn is_admin(env: &Env, admin: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Administrator(admin.clone()))
+        .unwrap_or(false)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn test_env() -> Env {
+        Env::default()
+    }
+
+    #[test]
+    fn add_then_query_returns_true() {
+        let env = test_env();
+        let admin = Address::generate(&env);
+
+        add_admin(&env, &admin);
+
+        assert!(is_admin(&env, &admin));
+    }
+
+    #[test]
+    fn remove_then_query_returns_false() {
+        let env = test_env();
+        let admin = Address::generate(&env);
+
+        add_admin(&env, &admin);
+        remove_admin(&env, &admin);
+
+        assert!(!is_admin(&env, &admin));
+    }
+
+    #[test]
+    fn query_before_add_returns_false() {
+        let env = test_env();
+        let admin = Address::generate(&env);
+
+        assert!(!is_admin(&env, &admin));
+    }
+
+    #[test]
+    fn add_same_admin_twice_is_idempotent() {
+        let env = test_env();
+        let admin = Address::generate(&env);
+
+        add_admin(&env, &admin);
+        add_admin(&env, &admin);
+
+        assert!(is_admin(&env, &admin));
+    }
+
+    #[test]
+    fn remove_non_existent_admin_is_noop() {
+        let env = test_env();
+        let admin = Address::generate(&env);
+
+        remove_admin(&env, &admin);
+
+        assert!(!is_admin(&env, &admin));
+    }
+
+    #[test]
+    fn multiple_distinct_admins_stored_independently() {
+        let env = test_env();
+        let admin_a = Address::generate(&env);
+        let admin_b = Address::generate(&env);
+        let admin_c = Address::generate(&env);
+
+        add_admin(&env, &admin_a);
+        add_admin(&env, &admin_b);
+
+        assert!(is_admin(&env, &admin_a));
+        assert!(is_admin(&env, &admin_b));
+        assert!(!is_admin(&env, &admin_c));
+
+        remove_admin(&env, &admin_b);
+
+        assert!(is_admin(&env, &admin_a));
+        assert!(!is_admin(&env, &admin_b));
+        assert!(!is_admin(&env, &admin_c));
+    }
+}

--- a/clips_nft/src/lib.rs
+++ b/clips_nft/src/lib.rs
@@ -207,6 +207,7 @@ pub use mint_authorization::{
 };
 
 // ─── Storage modules ──────────────────────────────────────────────────────────
+pub mod administrator_storage;
 pub mod clip_id_storage;
 pub mod creator_event;
 pub mod creator_storage;

--- a/clips_nft/src/types.rs
+++ b/clips_nft/src/types.rs
@@ -369,6 +369,8 @@ pub enum DataKey {
     // ── Token ownership (issue #505) ──────────────────────────────────────────
     /// Direct owner address for a token (dedicated ownership record).
     TokenOwner(TokenId),
+    /// Persistent storage key for checking multiple administrators (issue #494).
+    Administrator(Address),
 }
 
 #[contracterror]


### PR DESCRIPTION
### Description
Implements persistent storage for contract administrators, enabling support for multiple admin accounts.

### Changes
- Added the `Administrator(Address)` variant to the `DataKey` enum in `types.rs`.
- Created the `administrator_storage.rs` module with:
  - `add_admin`: Registers an address as an admin.
  - `remove_admin`: Revokes admin status from an address.
  - `is_admin`: Verifies if an address has administrator permissions.
- Added comprehensive unit tests for administrator storage operations.
- Registered the new module in `lib.rs`.

### Acceptance Criteria Checked
- [x] Add admin
- [x] Remove admin
- [x] Check admin

closes #494 