### PR TITLE
feat(storage): implement owner update and unit tests

### DIFF
--- a/clips_nft/src/owner_storage.rs
+++ b/clips_nft/src/owner_storage.rs
@@ -24,3 +24,58 @@ pub fn get_owner(env: &Env) -> Result<Address, Error> {
         .get(&DataKey::Admin)
         .ok_or(Error::NotInitialized)
 }
+
+/// Update the contract owner address.
+///
+/// # Errors
+/// Returns [`Error::NotInitialized`] if no owner has been stored.
+pub fn update_owner(env: &Env, new_owner: &Address) -> Result<(), Error> {
+    if !env.storage().instance().has(&DataKey::Admin) {
+        return Err(Error::NotInitialized);
+    }
+    env.storage().instance().set(&DataKey::Admin, new_owner);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn test_env() -> Env {
+        Env::default()
+    }
+
+    #[test]
+    fn test_save_and_get_owner() {
+        let env = test_env();
+        let owner = Address::generate(&env);
+
+        save_owner(&env, &owner);
+        assert_eq!(get_owner(&env), Ok(owner));
+    }
+
+    #[test]
+    fn test_get_owner_not_initialized() {
+        let env = test_env();
+        assert_eq!(get_owner(&env), Err(Error::NotInitialized));
+    }
+
+    #[test]
+    fn test_update_owner_success() {
+        let env = test_env();
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+
+        save_owner(&env, &owner_a);
+        assert_eq!(update_owner(&env, &owner_b), Ok(()));
+        assert_eq!(get_owner(&env), Ok(owner_b));
+    }
+
+    #[test]
+    fn test_update_owner_not_initialized() {
+        let env = test_env();
+        let owner = Address::generate(&env);
+        assert_eq!(update_owner(&env, &owner), Err(Error::NotInitialized));
+    }
+}


### PR DESCRIPTION
### Description
Enhances the persistent contract owner storage module with an update method and adds unit tests to verify owner storage operations.

### Changes
- Implemented `update_owner` in `owner_storage.rs` to allow modifying the contract owner, returning a `NotInitialized` error if no owner exists yet.
- Added a full test suite to `owner_storage.rs` covering:
  - Owner saving and reading
  - Get owner from uninitialized state
  - Owner updates
  - Update owner on uninitialized state

### Acceptance Criteria Checked
- [x] Save owner address
- [x] Read owner
- [x] Update owner

closes #493